### PR TITLE
fix: Wrong creds in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (C) 2021 ExplosionAI GmbH, 2017 Ines Montani
+Copyright (C) 2022 Centre For Humanities Computing Aarhus
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The license file was copied from spaCy, and had their name in it. Changed to Centre For Humanities Computing Aarhus instead, as well as updating the year to 2022.