### PR TITLE
Unit test deduper

### DIFF
--- a/dfm/cleaning/__init__.py
+++ b/dfm/cleaning/__init__.py
@@ -1,1 +1,2 @@
 from .quality import QualityFilter
+from .deduper import Deduper

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -60,6 +60,9 @@ class Deduper:
         normalization_func: (Callable[[str], str], optional):
             The function used to normalize documents before their are compared to
             ignore insignificant differences.
+        silent (bool, optional):
+            Silence the progress bar that otherwise prints to stdout. Defaults
+            to False.
 
     Attributes:
         split_method (str): The splitting method for extracting shingles.
@@ -69,6 +72,7 @@ class Deduper:
         num_minhashes (int): The number of MinHash functions to use.
         random_seed (int): The random seed to use for the MinHash functions.
         normalization_func (Callable): The function used for normalization.
+        silent (bool): Do not print progress to stdout.
 
     References:
         [1] Broder, Andrei Z. "On the resemblance and containment of documents."
@@ -85,6 +89,7 @@ class Deduper:
         num_minhashes: int = 128,
         random_seed: int = 42,
         normalization_func: Callable[[str], str] = _default_normalization,
+        silent: bool = False
     ):
         self.split_method = "none" if split_method is None else split_method
         self.ngram_size = ngram_size
@@ -93,6 +98,7 @@ class Deduper:
         self.num_minhashes = num_minhashes
         self.random_seed = random_seed
         self.normalization_func = normalization_func
+        self.silent = silent
 
     def deduplicate(
         self,
@@ -137,7 +143,7 @@ class Deduper:
 
         # Iterate over the corpus and store documents that are not duplicates
         duplicates = 0
-        with tqdm(corpus, desc="Deduplicating") as pbar:
+        with tqdm(corpus, desc="Deduplicating", disable=self.silent) as pbar:
             for doc_idx, doc in enumerate(pbar):
 
                 # Compute the fingerprint for the document

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -213,14 +213,14 @@ class Deduper:
             return [
                 doc[i : i + self.ngram_size]
                 for i in range(0, max_char_idx, self.ngram_stride)
-            ]
+            ] or [doc]
         elif self.split_method == "word_ngram":
             words = [word for word in doc.split(" ") if len(word) > 0]
             max_word_idx = len(words) - self.ngram_size
             return [
                 " ".join(words[i : i + self.ngram_size]).strip()
                 for i in range(0, max_word_idx, self.ngram_stride)
-            ]
+            ] or [doc]
         elif self.split_method == "paragraph":
             return [p for p in doc.split("\n") if len(p) > 0]
         elif self.split_method == "none":

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -60,7 +60,7 @@ class Deduper:
         random_seed (int, optional):
             The random seed to use for the MinHash functions. Defaults to 42.
         normalization_func: (Callable[[str], str], optional):
-            The function used to normalize documents before their are compared to
+            The function used to normalize documents before they are compared to
             ignore insignificant differences.
         silent (bool, optional):
             Silence the progress bar that otherwise prints to stdout. Defaults

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -209,14 +209,14 @@ class Deduper:
                 'paragraph' or 'none'.
         """
         if self.split_method == "char_ngram":
-            max_char_idx = len(doc) - self.ngram_size
+            max_char_idx = 1 + len(doc) - self.ngram_size
             return [
                 doc[i : i + self.ngram_size]
                 for i in range(0, max_char_idx, self.ngram_stride)
             ] or [doc]
         elif self.split_method == "word_ngram":
             words = [word for word in doc.split(" ") if len(word) > 0]
-            max_word_idx = len(words) - self.ngram_size
+            max_word_idx = 1 + len(words) - self.ngram_size
             return [
                 " ".join(words[i : i + self.ngram_size]).strip()
                 for i in range(0, max_word_idx, self.ngram_stride)

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -62,9 +62,8 @@ class Deduper:
         normalization_func: (Callable[[str], str], optional):
             The function used to normalize documents before they are compared to
             ignore insignificant differences.
-        silent (bool, optional):
-            Silence the progress bar that otherwise prints to stdout. Defaults
-            to False.
+        verbose (bool, optional):
+            Print progress to stdout. Defaults to True.
 
     Attributes:
         split_method (str): The splitting method for extracting shingles.
@@ -74,7 +73,7 @@ class Deduper:
         num_minhashes (int): The number of MinHash functions to use.
         random_seed (int): The random seed to use for the MinHash functions.
         normalization_func (Callable): The function used for normalization.
-        silent (bool): Do not print progress to stdout.
+        verbose (bool): Print progress to stdout.
 
     References:
         [1] Broder, Andrei Z. "On the resemblance and containment of documents."
@@ -91,7 +90,7 @@ class Deduper:
         num_minhashes: int = 128,
         random_seed: int = 42,
         normalization_func: Callable[[str], str] = _default_normalization,
-        silent: bool = False,
+        verbose: bool = True,
     ):
         self.split_method = "none" if split_method is None else split_method
         self.ngram_size = ngram_size
@@ -100,7 +99,7 @@ class Deduper:
         self.num_minhashes = num_minhashes
         self.random_seed = random_seed
         self.normalization_func = normalization_func
-        self.silent = silent
+        self.verbose = verbose
 
     def deduplicate(
         self,
@@ -145,7 +144,7 @@ class Deduper:
 
         # Iterate over the corpus and store documents that are not duplicates
         duplicates = 0
-        with tqdm(corpus, desc="Deduplicating", disable=self.silent) as pbar:
+        with tqdm(corpus, desc="Deduplicating", disable=not self.verbose) as pbar:
             for doc_idx, doc in enumerate(pbar):
 
                 # Compute the fingerprint for the document

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -23,7 +23,7 @@ from tqdm.auto import tqdm
 from collections.abc import Callable
 
 
-def _default_normalization(doc: str):
+def _default_normalization(doc: str) -> str:
     """NFKC normalise document and remove punctuation
 
     Args:

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -22,6 +22,7 @@ import re
 from tqdm.auto import tqdm
 from collections.abc import Callable
 
+
 def _default_normalization(doc: str):
     """NFKC normalise document and remove punctuation
 
@@ -31,6 +32,7 @@ def _default_normalization(doc: str):
     doc = normalize("NFKC", doc)
     doc = re.sub(r"[\.\,\:\;\!\?\(\)\[\]\{\}]", " ", doc)
     return re.sub(" +", " ", doc)
+
 
 class Deduper:
     """Class that deduplicates an iterable corpus.
@@ -89,7 +91,7 @@ class Deduper:
         num_minhashes: int = 128,
         random_seed: int = 42,
         normalization_func: Callable[[str], str] = _default_normalization,
-        silent: bool = False
+        silent: bool = False,
     ):
         self.split_method = "none" if split_method is None else split_method
         self.ngram_size = ngram_size
@@ -228,7 +230,6 @@ class Deduper:
         else:
             raise ValueError(f"Invalid split method: {self.split_method}")
 
-
     def _store_document(
         self, doc_idx: Union[str, int], doc: str, fname: Union[str, Path]
     ):
@@ -249,7 +250,6 @@ class Deduper:
         with fname.open("a") as f:
             jsonned = json.dumps(dict(id=doc_idx, text=doc))
             f.write(jsonned + "\n")
-
 
 
 if __name__ == "__main__":

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -20,7 +20,7 @@ import json
 from unicodedata import normalize
 import re
 from tqdm.auto import tqdm
-from collections.abc import Callable
+from typing import Callable
 
 
 def _default_normalization(doc: str) -> str:

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -155,7 +155,7 @@ class Deduper:
                 # cache and append it to the JSONL output file
                 if len(cache.query(minhash)) == 0:
                     cache.insert(doc_idx, minhash)
-                    self._store_document(doc_idx=doc_idx, doc=doc, fname=output_fname)
+                    self._store_document(doc_idx=doc_idx, doc=doc, output_fname=output_fname)
 
                 # Otherwise, increment the number of duplicate documents
                 else:
@@ -231,23 +231,23 @@ class Deduper:
             raise ValueError(f"Invalid split method: {self.split_method}")
 
     def _store_document(
-        self, doc_idx: Union[str, int], doc: str, fname: Union[str, Path]
+        self, doc_idx: Union[str, int], doc: str, output_fname: Union[str, Path]
     ):
         """Appends the document to a JSONL file.
 
         Args:
             doc_idx (str or int): The document index.
             doc (str): The document to append to the JSONL file.
-            fname (str or Path): The name of the JSONL file to append to.
+            output_fname (str or Path): The name of the JSONL file to append to.
         """
         # Ensure that `doc_idx` is a string
         doc_idx = str(doc_idx)
 
-        # Ensure that `fname` is a Path object
-        fname = Path(fname)
+        # Ensure that `output_fname` is a Path object
+        output_fname = Path(output_fname)
 
         # Append the document to the JSONL file
-        with fname.open("a") as f:
+        with output_fname.open("a") as f:
             jsonned = json.dumps(dict(id=doc_idx, text=doc))
             f.write(jsonned + "\n")
 

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -27,7 +27,9 @@ def _default_normalization(doc: str):
     """NFKC normalise document and remove punctuation
 
     Args:
-        doc (str): The document to normalize
+        doc (str): The document to normalize.
+    Returns:
+        doc (str): The normalized document.
     """
     doc = normalize("NFKC", doc)
     doc = re.sub(r"[\.\,\:\;\!\?\(\)\[\]\{\}]", " ", doc)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -12,6 +12,7 @@ class TestDeduper:
         default_args = {
             'random_seed': 42,
             'split_method': "char_ngram",
+            'silent': True
         }
         args = dict(default_args, **kwargs)
         deduper = Deduper(**args)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -34,14 +34,21 @@ class TestDeduper:
             ]) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
         )
 
+    def test_document_shorter_than_shingles(self):
+        assert (
+            self.dedup([
+                "Hej med dig",
+                "Hej med dig",
+                "Gå din vej"
+            ], ngram_size=13) == ["Hej med dig", "Gå din vej"]
+        )
+
     def test_split_by_5_char_ngram(self):
         pass
 
     def test_split_by_13_char_ngram(self):
         pass
 
-    def test_split_by_13_char_ngram_short_document(self):
-        pass
 
     def test_split_by_5_word_ngram(self):
         pass

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -1,0 +1,27 @@
+from dfm.cleaning import Deduper
+
+import pytest
+import tempfile
+from pathlib import Path
+import json
+
+class TestDeduper:
+    def dedup(self, corpus):
+        temp = tempfile.NamedTemporaryFile()
+        deduper = Deduper(split_method="none", random_seed=42, similarity_threshold=0.001, num_minhashes=2)
+        deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
+        return [json.loads(line)['text'] for line in Path(temp.name).open("r")]
+
+    def test_removes_exact_duplicates(self):
+        assert (
+            self.dedup(["hej", "hej", "farvel"]) == ["hej", "farvel"]
+        )
+
+    @pytest.mark.skip(reason="Not implemented")
+    def test_removes_near_duplicates(self):
+        assert (
+            self.dedup([
+                "Der kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'",
+                "er kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'"
+            ]) == ["Der kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'"]
+        )

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -19,6 +19,18 @@ class TestDeduper:
         deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
         return [json.loads(line)['text'] for line in Path(temp.name).open("r")]
 
+    def miss_percentage(self, corpus=None, iterations=100, **kwargs):
+        corpus = corpus or [
+                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                    "Da kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+                 ]
+        misses = 0
+        for i in range(0, iterations):
+            if len(self.dedup(corpus, random_seed=i, **kwargs)) == 2:
+                misses += 1
+        return (100.0 * misses)/iterations
+
+
     def test_removes_exact_duplicates(self):
         assert (
             self.dedup([
@@ -45,19 +57,6 @@ class TestDeduper:
             ], ngram_size=13) == ["Hej med dig", "Gå din vej"]
         )
 
-    def test_split_by_5_char_ngram(self):
-        pass
-
-    def test_split_by_13_char_ngram(self):
-        pass
-
-
-    def test_split_by_5_word_ngram(self):
-        pass
-
-    def test_split_by_13_word_ngram(self):
-        pass
-
     def test_split_by_paragraph(self):
         assert (
             self.dedup([
@@ -80,21 +79,6 @@ class TestDeduper:
             ]
         )
 
-    def test_split_with_double_stride(self):
-        pass
-
-    def test_2_minhashes(self):
-        pass
-
-    def test_128_minhashes(self):
-        pass
-
-    def test_2048_minhashes(self):
-        pass
-
-    def test_seed_stability(self):
-        pass
-
     def test_no_normalization(self):
         identity = lambda doc: doc
         assert (
@@ -115,3 +99,38 @@ class TestDeduper:
                 "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!"
             ], normalization_func=word_shape) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
         )
+
+    def test_2_minhashes(self):
+        miss = self.miss_percentage(num_minhashes=2)
+        assert (miss > 10)
+        assert (miss < 20)
+
+    def test_128_minhashes(self):
+        miss = self.miss_percentage()
+        assert (miss > 5)
+        assert (miss < 10)
+
+    def test_256_minhashes(self):
+        miss = self.miss_percentage(num_minhashes=256)
+        assert (miss > 0)
+        assert (miss < 2)
+
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_split_with_double_stride(self):
+        pass
+
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_split_by_5_char_ngram(self):
+        pass
+
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_split_by_13_char_ngram(self):
+        pass
+
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_split_by_5_word_ngram(self):
+        pass
+
+    @pytest.mark.skip(reason="Not implemented yet")
+    def test_split_by_13_word_ngram(self):
+        pass

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -117,22 +117,46 @@ class TestDeduper:
         miss = self.miss_percentage(num_minhashes=256)
         assert (miss < 2)
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_split_with_double_stride(self):
+    def test_13_char_shingles(self):
+        shingles = self.deduper()._extract_shingles("Hej med dig Kim")
+        assert(
+            shingles == [
+                "Hej med dig K",
+                "ej med dig Ki",
+                "j med dig Kim"
+            ])
         pass
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_split_by_5_char_ngram(self):
-        pass
+    def test_5_char_shingles(self):
+        shingles = self.deduper(ngram_size=5)._extract_shingles("Hej med dig Kim")
+        assert(
+            shingles == [
+                'Hej m',
+                'ej me',
+                'j med',
+                ' med ',
+                'med d',
+                'ed di',
+                'd dig',
+                ' dig ',
+                'dig K',
+                'ig Ki',
+                'g Kim',
+            ])
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_split_by_13_char_ngram(self):
-        pass
+    def test_double_stride_shingles(self):
+        shingles = self.deduper(ngram_stride=2)._extract_shingles("Hej med dig Kim")
+        assert(
+            shingles == [
+                "Hej med dig K",
+                "j med dig Kim"
+            ])
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_split_by_5_word_ngram(self):
-        pass
-
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_split_by_13_word_ngram(self):
-        pass
+    def test_5_word_shingles(self):
+        deduper = self.deduper(ngram_size=5, split_method='word_ngram')
+        shingles = deduper._extract_shingles("Hej med dig,\n hvordan går det?")
+        assert(
+            shingles == [
+                "Hej med dig,\n hvordan går",
+                "med dig,\n hvordan går det?"
+            ])

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -7,15 +7,16 @@ import json
 import re
 
 class TestDeduper:
-    def dedup(self, corpus, **kwargs):
-        temp = tempfile.NamedTemporaryFile()
-        default_args = {
+    def deduper(self, **kwargs):
+        default_test_args = {
             'random_seed': 42,
-            'split_method': "char_ngram",
             'silent': True
         }
-        args = dict(default_args, **kwargs)
-        deduper = Deduper(**args)
+        return Deduper(**dict(default_test_args, **kwargs))
+
+    def dedup(self, corpus, **kwargs):
+        temp = tempfile.NamedTemporaryFile()
+        deduper = self.deduper(**kwargs)
         deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
         return [json.loads(line)['text'] for line in Path(temp.name).open("r")]
 

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -4,6 +4,7 @@ import pytest
 import tempfile
 from pathlib import Path
 import json
+import re
 
 class TestDeduper:
     def dedup(self, corpus, **kwargs):
@@ -94,7 +95,22 @@ class TestDeduper:
         pass
 
     def test_no_normalization(self):
-        pass
+        identity = lambda doc: doc
+        assert (
+            self.dedup([
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
+            ], normalization_func=identity) == [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
+                ]
+        )
 
     def test_aggresive_normalization(self):
-        pass
+        word_shape = lambda doc: re.sub('[A-Z]', 'X', re.sub('[^A-Z ]', 'x', doc))
+        assert (
+            self.dedup([
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!"
+            ], normalization_func=word_shape) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+        )

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -6,22 +6,72 @@ from pathlib import Path
 import json
 
 class TestDeduper:
-    def dedup(self, corpus):
+    def dedup(self, corpus, **kwargs):
         temp = tempfile.NamedTemporaryFile()
-        deduper = Deduper(split_method="none", random_seed=42, similarity_threshold=0.001, num_minhashes=2)
+        default_args = {
+            'random_seed': 42,
+            'split_method': "char_ngram",
+        }
+        args = dict(default_args, **kwargs)
+        deduper = Deduper(**args)
         deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
         return [json.loads(line)['text'] for line in Path(temp.name).open("r")]
 
     def test_removes_exact_duplicates(self):
         assert (
-            self.dedup(["hej", "hej", "farvel"]) == ["hej", "farvel"]
+            self.dedup([
+                "hej med dig min ven",
+                "hej med dig min ven",
+                "farvel du gamle"
+            ]) == ["hej med dig min ven", "farvel du gamle"]
         )
 
-    @pytest.mark.skip(reason="Not implemented")
     def test_removes_near_duplicates(self):
         assert (
             self.dedup([
-                "Der kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'",
-                "er kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'"
-            ]) == ["Der kom en soldat marcherende hen ad landevejen: én, to! én, to! Han havde sit tornyster på ryggen og en sabel ved siden, for han havde været i krigen, og nu skulle han hjem. Så mødte han en gammel heks på landevejen; hun var så ækel, hendes underlæbe hang hende lige ned på brystet. Hun sagde: 'God aften, soldat! Hvor du har en pæn sabel og et stort tornyster, du er en rigtig soldat! Nu skal du få så mange penge, du vil eje!'"]
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ]) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
         )
+
+    def test_split_by_5_char_ngram(self):
+        pass
+
+    def test_split_by_13_char_ngram(self):
+        pass
+
+    def test_split_by_13_char_ngram_short_document(self):
+        pass
+
+    def test_split_by_5_word_ngram(self):
+        pass
+
+    def test_split_by_13_word_ngram(self):
+        pass
+
+    def test_split_by_paragraph(self):
+        pass
+
+    def test_do_not_split(self):
+        pass
+
+    def test_split_with_double_stride(self):
+        pass
+
+    def test_2_minhashes(self):
+        pass
+
+    def test_128_minhashes(self):
+        pass
+
+    def test_2048_minhashes(self):
+        pass
+
+    def test_seed_stability(self):
+        pass
+
+    def test_no_normalization(self):
+        pass
+
+    def test_aggresive_normalization(self):
+        pass

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -9,7 +9,7 @@ import re
 
 class TestDeduper:
     def deduper(self, **kwargs):
-        default_test_args = {"random_seed": 42, "silent": True}
+        default_test_args = {"random_seed": 42, "verbose": False}
         return Deduper(**dict(default_test_args, **kwargs))
 
     def dedup(self, corpus, **kwargs):

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -47,6 +47,28 @@ class TestDeduper:
             ["Hej med dig", "Hej med dig", "Gå din vej"], ngram_size=13
         ) == ["Hej med dig", "Gå din vej"]
 
+    def test_split_by_char_ngram(self):
+        assert self.dedup(
+            [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            split_method="char_ngram", ngram_size=5,
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+        ]
+
+    def test_split_by_word_ngram(self):
+        assert self.dedup(
+            [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            split_method="word_ngram", ngram_size=5,
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+        ]
+
     def test_split_by_paragraph(self):
         assert self.dedup(
             [

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -107,12 +107,11 @@ class TestDeduper:
 
     def test_128_minhashes(self):
         miss = self.miss_percentage()
-        assert (miss > 5)
+        assert (miss > 2)
         assert (miss < 10)
 
     def test_256_minhashes(self):
         miss = self.miss_percentage(num_minhashes=256)
-        assert (miss > 0)
         assert (miss < 2)
 
     @pytest.mark.skip(reason="Not implemented yet")

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -6,157 +6,134 @@ from pathlib import Path
 import json
 import re
 
+
 class TestDeduper:
     def deduper(self, **kwargs):
-        default_test_args = {
-            'random_seed': 42,
-            'silent': True
-        }
+        default_test_args = {"random_seed": 42, "silent": True}
         return Deduper(**dict(default_test_args, **kwargs))
 
     def dedup(self, corpus, **kwargs):
         temp = tempfile.NamedTemporaryFile()
         deduper = self.deduper(**kwargs)
         deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
-        return [json.loads(line)['text'] for line in Path(temp.name).open("r")]
+        return [json.loads(line)["text"] for line in Path(temp.name).open("r")]
 
     def miss_percentage(self, corpus=None, iterations=100, **kwargs):
         corpus = corpus or [
-                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                    "Da kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-                 ]
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            "Da kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+        ]
         misses = 0
         for i in range(0, iterations):
             if len(self.dedup(corpus, random_seed=i, **kwargs)) == 2:
                 misses += 1
-        return (100.0 * misses)/iterations
-
+        return (100.0 * misses) / iterations
 
     def test_removes_exact_duplicates(self):
-        assert (
-            self.dedup([
-                "hej med dig min ven",
-                "hej med dig min ven",
-                "farvel du gamle"
-            ]) == ["hej med dig min ven", "farvel du gamle"]
-        )
+        assert self.dedup(
+            ["hej med dig min ven", "hej med dig min ven", "farvel du gamle"]
+        ) == ["hej med dig min ven", "farvel du gamle"]
 
     def test_removes_near_duplicates(self):
-        assert (
-            self.dedup([
+        assert self.dedup(
+            [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ]) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
-        )
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ]
+        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
 
     def test_document_shorter_than_shingles(self):
-        assert (
-            self.dedup([
-                "Hej med dig",
-                "Hej med dig",
-                "Gå din vej"
-            ], ngram_size=13) == ["Hej med dig", "Gå din vej"]
-        )
+        assert self.dedup(
+            ["Hej med dig", "Hej med dig", "Gå din vej"], ngram_size=13
+        ) == ["Hej med dig", "Gå din vej"]
 
     def test_split_by_paragraph(self):
-        assert (
-            self.dedup([
+        assert self.dedup(
+            [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ], split_method='paragraph') == [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ]
-        )
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            split_method="paragraph",
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+        ]
 
     def test_do_not_split(self):
-        assert (
-            self.dedup([
+        assert self.dedup(
+            [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ], split_method='paragraph') == [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ]
-        )
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            split_method="paragraph",
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+        ]
 
     def test_no_normalization(self):
         identity = lambda doc: doc
-        assert (
-            self.dedup([
+        assert self.dedup(
+            [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
                 "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
-            ], normalization_func=identity) == [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
-                ]
-        )
+            ],
+            normalization_func=identity,
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
+        ]
 
     def test_aggresive_normalization(self):
-        word_shape = lambda doc: re.sub('[A-Z]', 'X', re.sub('[^A-Z ]', 'x', doc))
-        assert (
-            self.dedup([
+        word_shape = lambda doc: re.sub("[A-Z]", "X", re.sub("[^A-Z ]", "x", doc))
+        assert self.dedup(
+            [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!"
-            ], normalization_func=word_shape) == [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
-            ]
-        )
+                "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!",
+            ],
+            normalization_func=word_shape,
+        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
 
     def test_2_minhashes(self):
         miss = self.miss_percentage(num_minhashes=2)
-        assert (miss > 10)
-        assert (miss < 20)
+        assert miss > 10
+        assert miss < 20
 
     def test_128_minhashes(self):
         miss = self.miss_percentage()
-        assert (miss > 2)
-        assert (miss < 10)
+        assert miss > 2
+        assert miss < 10
 
     def test_256_minhashes(self):
         miss = self.miss_percentage(num_minhashes=256)
-        assert (miss < 2)
+        assert miss < 2
 
     def test_13_char_shingles(self):
         shingles = self.deduper()._extract_shingles("Hej med dig Kim")
-        assert(
-            shingles == [
-                "Hej med dig K",
-                "ej med dig Ki",
-                "j med dig Kim"
-            ])
+        assert shingles == ["Hej med dig K", "ej med dig Ki", "j med dig Kim"]
         pass
 
     def test_5_char_shingles(self):
         shingles = self.deduper(ngram_size=5)._extract_shingles("Hej med dig Kim")
-        assert(
-            shingles == [
-                'Hej m',
-                'ej me',
-                'j med',
-                ' med ',
-                'med d',
-                'ed di',
-                'd dig',
-                ' dig ',
-                'dig K',
-                'ig Ki',
-                'g Kim',
-            ])
+        assert shingles == [
+            "Hej m",
+            "ej me",
+            "j med",
+            " med ",
+            "med d",
+            "ed di",
+            "d dig",
+            " dig ",
+            "dig K",
+            "ig Ki",
+            "g Kim",
+        ]
 
     def test_double_stride_shingles(self):
         shingles = self.deduper(ngram_stride=2)._extract_shingles("Hej med dig Kim")
-        assert(
-            shingles == [
-                "Hej med dig K",
-                "j med dig Kim"
-            ])
+        assert shingles == ["Hej med dig K", "j med dig Kim"]
 
     def test_5_word_shingles(self):
-        deduper = self.deduper(ngram_size=5, split_method='word_ngram')
+        deduper = self.deduper(ngram_size=5, split_method="word_ngram")
         shingles = deduper._extract_shingles("Hej med dig,\n hvordan går det?")
-        assert(
-            shingles == [
-                "Hej med dig,\n hvordan går",
-                "med dig,\n hvordan går det?"
-            ])
+        assert shingles == ["Hej med dig,\n hvordan går", "med dig,\n hvordan går det?"]

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -111,7 +111,6 @@ class TestDeduper:
     def test_13_char_shingles(self):
         shingles = self.deduper()._extract_shingles("Hej med dig Kim")
         assert shingles == ["Hej med dig K", "ej med dig Ki", "j med dig Kim"]
-        pass
 
     def test_5_char_shingles(self):
         shingles = self.deduper(ngram_size=5)._extract_shingles("Hej med dig Kim")

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -98,7 +98,9 @@ class TestDeduper:
             self.dedup([
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
                 "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!"
-            ], normalization_func=word_shape) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+            ], normalization_func=word_shape) == [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ]
         )
 
     def test_2_minhashes(self):

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -65,7 +65,7 @@ class TestDeduper:
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
                 "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
             ],
-            split_method="paragraph",
+            split_method="none",
         ) == [
             "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
             "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -57,10 +57,26 @@ class TestDeduper:
         pass
 
     def test_split_by_paragraph(self):
-        pass
+        assert (
+            self.dedup([
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ], split_method='paragraph') == [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ]
+        )
 
     def test_do_not_split(self):
-        pass
+        assert (
+            self.dedup([
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ], split_method='paragraph') == [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"
+            ]
+        )
 
     def test_split_with_double_stride(self):
         pass

--- a/tests/cleaning/quality_test.py
+++ b/tests/cleaning/quality_test.py
@@ -1,7 +1,6 @@
 from dfm.cleaning import QualityFilter
 import pytest
 
-
 class TestQualityFilter:
     """Unit tests for the QualityFilter class"""
 

--- a/tests/cleaning/quality_test.py
+++ b/tests/cleaning/quality_test.py
@@ -1,6 +1,7 @@
 from dfm.cleaning import QualityFilter
 import pytest
 
+
 class TestQualityFilter:
     """Unit tests for the QualityFilter class"""
 

--- a/tests/tokenizers/train_tokenizer_test.py
+++ b/tests/tokenizers/train_tokenizer_test.py
@@ -30,7 +30,10 @@ def valid_config_dict():
         mask_token="<mask>",
     )
 
+<<<<<<< HEAD:tests/tokenizers/train_tokenizer_test.py
 
+=======
+>>>>>>> rearrange tests to follow library structure:tests/tokenizers/train_tokenizer_test.py
 class TestTrainTokenizer:
     """Unit tests for the tok = train_tokenizer function"""
 

--- a/tests/tokenizers/train_tokenizer_test.py
+++ b/tests/tokenizers/train_tokenizer_test.py
@@ -30,10 +30,7 @@ def valid_config_dict():
         mask_token="<mask>",
     )
 
-<<<<<<< HEAD:tests/tokenizers/train_tokenizer_test.py
 
-=======
->>>>>>> rearrange tests to follow library structure:tests/tokenizers/train_tokenizer_test.py
 class TestTrainTokenizer:
     """Unit tests for the tok = train_tokenizer function"""
 


### PR DESCRIPTION
Depends on https://github.com/centre-for-humanities-computing/danish-foundation-models/pull/46

This PR adds unittests and general improvements to the deduper.

# Code improvements (subjective)
- Extracted a few methods to make tests and comprehension easier

# Features
- `silent` parameter to not print progress (useful for testing)
- `normalization_func` parameter to give user defined callback as document normalization. The old normalization has been set as the default function

# Bugfixes
- Shingles no longer forgets the last token ("abc" of char ngram size 1 becomes "a,b,c" not just "a,b")
- For documents shorter than the shingle size, we now return a single shingle ("Hej med dig" of char_ngram_size 13 becomes ["Hej med dig"] not just [].) This avoid deduplicating short but completely different documents (They would all return the same empty fingerprint).