### PR TITLE
Allow usage of hashing trick instead of shingles

### DIFF
--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -137,3 +137,16 @@ class TestDeduper:
         deduper = self.deduper(ngram_size=5, split_method="word_ngram")
         shingles = deduper._extract_shingles("Hej med dig,\n hvordan går det?")
         assert shingles == ["Hej med dig,\n hvordan går", "med dig,\n hvordan går det?"]
+
+    def test_feature_hasher(self):
+        assert self.dedup(
+            [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            hash_calculation_method="feature_hasher",
+        ) == [
+            "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+        ]


### PR DESCRIPTION
Depends on https://github.com/centre-for-humanities-computing/danish-foundation-models/pull/47

This allows the deduper to use the hashing trick instead of shingles.

Mention here (from https://arxiv.org/pdf/2201.11990.pdf)
```
Exact match duplicates would be computationally expensive, so we opted to take a fuzzy deduplication
approach similar to other works [9, 17]. We used a hashing vectorizer with 1,048,576 features to vectorize
documents (HashingVectorizer from scikit-learn4
), calculated min-hashes of the vectorized documents
(using datasketch5
), and performed Locality Sensitive Hashing (LSH) through datasketch on all minhashes in order to identify potential duplicates. We set our LSH parameters in such a way as to increase the
likelihood that documents with Jaccard similarity ≥ 0.8 would occur in at least one LSH bucket together.
Specifically, we used 20 bands of size 13 for a total of 260 hash functions.
```

Do note that I don't see why using the hashing trick here gives any advantage? Perhaps the implementation in the paper uses multiple passes and thus have to store the vectors? Given that this only uses a single pass, I don't see why it would improve anything. @saattrupdan what do you think?