### PR TITLE
Prepare tokenizer training for new versions of `tokenizers` package

### DIFF
--- a/dfm/dfm_tokenizers/train_tokenizer.py
+++ b/dfm/dfm_tokenizers/train_tokenizer.py
@@ -66,11 +66,11 @@ def train_tokenizer(
 
     # Initialise the special tokens and add them to the tokenizer
     special_tokens = [
-        AddedToken(config.pad_token, single_word=True, normalized=False),
-        AddedToken(config.bos_token, single_word=True, normalized=False),
-        AddedToken(config.eos_token, single_word=True, normalized=False),
-        AddedToken(config.unk_token, single_word=True, normalized=False),
-        AddedToken(config.mask_token, single_word=True, normalized=False),
+        AddedToken(config.pad_token, single_word=False, normalized=False),
+        AddedToken(config.bos_token, single_word=False, normalized=False),
+        AddedToken(config.eos_token, single_word=False, normalized=False),
+        AddedToken(config.unk_token, single_word=False, normalized=False),
+        AddedToken(config.mask_token, single_word=False, normalized=False),
     ]
     tokenizer.add_special_tokens(special_tokens)
 


### PR DESCRIPTION
As per [this Github issue](https://github.com/huggingface/tokenizers/issues/918), there is a bug with versions 0.11.3, 0.11.4 and 0.11.5 of the `tokenizers` package. Narsil was kind to locate the bug and to open a PR, so that will be fixed soon. 

However, as another by-product of this update, the `single_word` argument in `AddedToken` will now work _correctly_. I realised that we've been using it incorrectly, but because the `tokenizers` package was buggy it didn't make a difference previously.

Long story short, this tiny fix will ensure that
```python
'Dette er <mask>.'
'Dette er <mask>,'
'Dette er <mask>-'
'Dette er <mask>0'
'Dette er <mask>a'
```

are tokenised as
```python
['Dette', 'er', '<mask>', '.']
['Dette', 'er', '<mask>', ',']
['Dette', 'er', '<mask>', '-']
['Dette', 'er', '<mask>', '0']
['Dette', 'er', '<mask>', 'a']
```

rather than
```python
['Dette', 'er', '<', 'm', 'a', 's', 'k, '>', '.']
['Dette', 'er', '<', 'm', 'a', 's', 'k, '>', ',']
['Dette', 'er', '<', 'm', 'a', 's', 'k, '>', '-']
['Dette', 'er', '<', 'm', 'a', 's', 'k, '>', '0']
['Dette', 'er', '<', 'm', 'a', 's', 'k, '>', 'a']
```

Again, I emphasise that this makes _no difference at all_ with our current version of `tokenizers`, but it will allow us to use newer versions with no harm.