### PR TITLE
Deduper checkpoints

### DIFF
--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -373,19 +373,19 @@ class Deduper:
                     candidates = self.lsh_cache.query(minhash)
                     if len(candidates) == 0:
 
-                        # Insert the document into the LSH cache
+                        # Insert the document into the LSH cache
                         self.lsh_cache.insert(doc_idx, minhash)
 
-                        # Store the LSH cache to disk
+                        # Store the LSH cache to disk
                         with lsh_cache_path.open("wb") as f:
                             pickle.dump(self.lsh_cache, f)
 
-                        # Store the non-duplicate document in the JSONL output
+                        # Store the non-duplicate document in the JSONL output
                         self._store_document(
-                            doc_idx=doc_idx, text=doc, output_path=output_path
+                            id=doc_idx, text=doc, output_path=output_path
                         )
 
-                        # Add the current document to the Boolean mask
+                        # Add the current document to the Boolean mask
                         mask_entry = dict(id=doc_idx, duplicate=False)
                         self.mask.append(mask_entry)
 

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -145,6 +145,48 @@ class Deduper:
         )
         return self
 
+    @classmethod
+    def load_from_disk(cls, directory: Union[str, Path]) -> "Deduper":
+        """Load a Deduper from disk.
+
+        Args:
+            directory (str or Path):
+                The directory to load the Deduper from.
+
+        Returns:
+            Deduper:
+                The Deduper loaded from disk.
+
+        Raises:
+            FileNotFoundError:
+                If the directory does not exist.
+        """
+        # Ensure that `directory` is a Path
+        directory = Path(directory)
+
+        # Check if the directory exists, and raise an error if it doesn't
+        if not directory.exists():
+            raise FileNotFoundError(f"Directory {directory} does not exist.")
+
+        # Load the config file
+        with open(directory / "config.pkl", "rb") as f:
+            config = pickle.load(f)
+
+        # Create the Deduper
+        deduper = cls(**config)
+
+        # Load the mask
+        with open(directory / "mask.jsonl", "r") as f:
+            mask = [json.loads(line) for line in f]
+        deduper.mask = mask
+
+        # Load the LSH cache
+        with open(directory / "lsh_cache.pkl", "rb") as f:
+            deduper.lsh_cache = pickle.load(f)
+
+        # Return the Deduper
+        return deduper
+
     def get_config(self) -> dict:
         """Get the configuration of the deduplicator.
 

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -120,6 +120,9 @@ class Deduper:
         self.normalization_func = normalization_func
         self.verbose = verbose
         self.mask = list()
+        self.lsh_cache = MinHashLSH(
+            threshold=self.similarity_threshold, num_perm=self.num_minhashes
+        )
 
         if batch_size is None:
             if self.split_method in ["paragraph", "none"] or self.split_method is None:

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -193,16 +193,18 @@ class Deduper:
         Returns:
             dict: The configuration of the deduplicator.
         """
-        config = dict(split_method=self.split_method,
-                      ngram_size=self.ngram_size,
-                      ngram_stride=self.ngram_stride,
-                      similarity_threshold=self.similarity_threshold,
-                      num_minhashes=self.num_minhashes,
-                      batch_size=self.batch_size,
-                      n_jobs=self.n_jobs,
-                      random_seed=self.random_seed,
-                      normalization_func=self.normalization_func,
-                      verbose=self.verbose)
+        config = dict(
+            split_method=self.split_method,
+            ngram_size=self.ngram_size,
+            ngram_stride=self.ngram_stride,
+            similarity_threshold=self.similarity_threshold,
+            num_minhashes=self.num_minhashes,
+            batch_size=self.batch_size,
+            n_jobs=self.n_jobs,
+            random_seed=self.random_seed,
+            normalization_func=self.normalization_func,
+            verbose=self.verbose,
+        )
         return config
 
     def _get_shingles(self, doc: str) -> List[str]:
@@ -315,7 +317,11 @@ class Deduper:
 
         # Convert corpus to an iterable of strings if a Dataset is given
         if isinstance(corpus, Dataset) or isinstance(corpus, IterableDataset):
-            corpus = (sample["text"] for sample in corpus)
+            corpus = (
+                sample["text"]
+                for doc_idx, sample in enumerate(corpus)
+                if doc_idx not in [i for i, _ in self.mask]
+            )
 
         # Ensure that `output_dir` is a Path object
         output_dir = Path(output_dir)

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -137,6 +137,14 @@ class Deduper:
         else:
             self.batch_size = batch_size
 
+    def reset(self):
+        """Reset the deduplicator, removing the mask and the LSH cache"""
+        self.mask = list()
+        self.lsh_cache = MinHashLSH(
+            threshold=self.similarity_threshold, num_perm=self.num_minhashes
+        )
+        return self
+
     def get_config(self) -> dict:
         """Get the configuration of the deduplicator.
 

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -373,19 +373,19 @@ class Deduper:
                     candidates = self.lsh_cache.query(minhash)
                     if len(candidates) == 0:
 
-                        # Insert the document into the LSH cache
+                        # Insert the document into the LSH cache
                         self.lsh_cache.insert(doc_idx, minhash)
 
-                        # Store the LSH cache to disk
+                        # Store the LSH cache to disk
                         with lsh_cache_path.open("wb") as f:
                             pickle.dump(self.lsh_cache, f)
 
-                        # Store the non-duplicate document in the JSONL output
+                        # Store the non-duplicate document in the JSONL output
                         self._store_document(
                             id=doc_idx, text=doc, output_path=output_path
                         )
 
-                        # Add the current document to the Boolean mask
+                        # Add the current document to the Boolean mask
                         mask_entry = dict(id=doc_idx, duplicate=False)
                         self.mask.append(mask_entry)
 

--- a/dfm/cleaning/deduper.py
+++ b/dfm/cleaning/deduper.py
@@ -75,7 +75,7 @@ class Deduper:
             The random seed to use for the MinHash functions. Defaults to 42.
         normalization_func: (Callable[[str], str], optional):
             The function used to normalize documents before they are compared to
-            ignore insignificant differences.
+            ignore insignificant differences. Needs to be pickleable.
         verbose (bool, optional):
             Print progress to stdout. Defaults to True.
 

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -37,11 +37,11 @@ class TestDeduper:
         return Deduper(**dict(default_test_args, **kwargs))
 
     def dedup(self, corpus, **kwargs):
-        temp = tempfile.TemporaryDirectory()
-        deduper = self.deduper(**kwargs)
-        deduper.deduplicate(corpus, output_dir=str(temp), overwrite=True)
-        deduped_corpus = Path(str(temp)) / "deduplicated_corpus.jsonl"
-        return [json.loads(line)["text"] for line in deduped_corpus.open("r")]
+        with tempfile.TemporaryDirectory() as temp:
+            deduper = self.deduper(**kwargs)
+            deduper.deduplicate(corpus, output_dir=temp, overwrite=True)
+            deduped_corpus = Path(temp) / "deduplicated_corpus.jsonl"
+            return [json.loads(line)["text"] for line in deduped_corpus.open("r")]
 
     def miss_percentage(self, corpus=None, iterations=100, **kwargs):
         corpus = corpus or [

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -37,10 +37,11 @@ class TestDeduper:
         return Deduper(**dict(default_test_args, **kwargs))
 
     def dedup(self, corpus, **kwargs):
-        temp = tempfile.NamedTemporaryFile()
+        temp = tempfile.TemporaryDirectory()
         deduper = self.deduper(**kwargs)
-        deduper.deduplicate(corpus, output_fname=temp.name, overwrite=True)
-        return [json.loads(line)["text"] for line in Path(temp.name).open("r")]
+        deduper.deduplicate(corpus, output_dir=str(temp), overwrite=True)
+        deduped_corpus = Path(str(temp)) / "deduplicated_corpus.jsonl"
+        return [json.loads(line)["text"] for line in deduped_corpus.open("r")]
 
     def miss_percentage(self, corpus=None, iterations=100, **kwargs):
         corpus = corpus or [

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -7,6 +7,30 @@ import json
 import re
 
 
+def word_shape(doc: str) -> str:
+    '''Aggressive normalization function used in unit tests.
+
+    Args:
+        doc (str): The document to normalize.
+
+    Returns:
+        str: The normalized document.
+    '''
+    return re.sub("[A-Z]", "X", re.sub("[^A-Z ]", "x", doc))
+
+
+def identity_fn(doc: str) -> str:
+    '''Identity function used in unit tests.
+
+    Args:
+        doc (str): The document to normalize.
+
+    Returns:
+        str: The normalized document.
+    '''
+    return doc
+
+
 class TestDeduper:
     def deduper(self, **kwargs):
         default_test_args = dict(ngram_size=1, random_seed=42, verbose=False)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -8,26 +8,26 @@ import re
 
 
 def word_shape(doc: str) -> str:
-    '''Aggressive normalization function used in unit tests.
+    """Aggressive normalization function used in unit tests.
 
     Args:
         doc (str): The document to normalize.
 
     Returns:
         str: The normalized document.
-    '''
+    """
     return re.sub("[A-Z]", "X", re.sub("[^A-Z ]", "x", doc))
 
 
 def identity_fn(doc: str) -> str:
-    '''Identity function used in unit tests.
+    """Identity function used in unit tests.
 
     Args:
         doc (str): The document to normalize.
 
     Returns:
         str: The normalized document.
-    '''
+    """
     return doc
 
 
@@ -177,7 +177,7 @@ class TestDeduper:
             loaded_deduper = Deduper.load_from_disk(temp)
             new_deduper = self.deduper()
 
-            # Test that the loaded config is the same as the original
+            # Test that the loaded config is the same as the original
             assert loaded_deduper.get_config() == deduper.get_config()
             assert new_deduper.get_config() != deduper.get_config()
 
@@ -185,7 +185,7 @@ class TestDeduper:
             assert loaded_deduper.mask == deduper.mask
             assert new_deduper.mask != deduper.mask
 
-            # Test that the loaded LSH cache works as intended
+            # Test that the loaded LSH cache works as intended
             minhash = deduper._get_minhash(corpus[0])
             assert len(loaded_deduper.lsh_cache.query(minhash)) > 0
             assert len(new_deduper.lsh_cache.query(minhash)) == 0

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -160,3 +160,9 @@ class TestDeduper:
     def test_double_stride_shingles(self):
         shingles = self.deduper(ngram_stride=2)._get_shingles("Hej med dig Kim")
         assert shingles == ["Hej", "dig"]
+
+    def test_get_config(self):
+        deduper = self.deduper()
+        config = deduper.get_config()
+        for key, val in config.items():
+            assert val == getattr(deduper, key)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -114,20 +114,18 @@ class TestDeduper:
         ]
 
     def test_no_normalization(self):
-        identity = lambda doc: doc
         assert self.dedup(
             [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
                 "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
             ],
-            normalization_func=identity,
+            normalization_func=identity_fn,
         ) == [
             "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
             "Der kom en soldat marcherende hen ad landevejen!\n én. to? én; to?",
         ]
 
     def test_aggresive_normalization(self):
-        word_shape = lambda doc: re.sub("[A-Z]", "X", re.sub("[^A-Z ]", "x", doc))
         assert self.dedup(
             [
                 "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",


### PR DESCRIPTION
Enable checkpointing of the deduper. This saves the internal state of the deduper during deduplication, so that it can be reloaded in case the script crashes.

Usage:
```python
>>> deduper = Deduper.load_from_disk('path/to/deduper/dir')
>>> deduper.deduplicate(corpus)
```

Further, the internal LSH cache is now stored as `deduper.lsh_cache`, a list of records `dict(id: int, duplicate: bool)` is stored in `deduper.mask` and the configuration can be fetched with `deduper.get_config()`. During deduplication these are stored in the `output_dir` folder, which is specified during initialisation.

If one does not want to reset these internal variables then simply call `deduper.reset()`. This does not affect the files on disk, however.