### PR TITLE
Deduper changes

### DIFF
--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -324,10 +324,12 @@ class Deduper:
                     batch, batch_copy = it.tee(batch)
 
                     # Compute the fingerprint for the document
+                    pbar_params['desc'] = 'Computing minhashes'
                     with tqdm(batch, **pbar_params) as batch_pbar:
                         minhashes = parallel(fn(doc) for _, doc in batch_pbar)
 
                     # Iterate over the minhashes
+                    pbar_params['desc'] = 'Deduplicating batch'
                     with tqdm(batch_copy, **pbar_params) as batch_pbar:
                         for (idx, doc), minhash in zip(batch_pbar, minhashes):
 

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -329,7 +329,9 @@ class Deduper:
                     batch_size = new_num_processed - num_processed
 
                     # Define parameters used in batch progress bars
-                    pbar_params = dict(total=batch_size, leave=False)
+                    pbar_params = dict(total=batch_size,
+                                       leave=False,
+                                       disable=(not self.verbose))
 
                     # Compute the fingerprint for the document
                     pbar_params['desc'] = 'Computing minhashes'
@@ -387,6 +389,12 @@ class Deduper:
                     pct_duplicated = 100 * duplicates / num_processed
                     desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                     pbar.set_description(desc)
+
+        # Return final update
+        if self.verbose:
+            print('Finished deduplicating corpus.')
+            print(f"- {num_processed:,} documents processed")
+            print(f"- {pct_duplicated:.2f}% documents marked as duplicates")
 
 
 if __name__ == "__main__":

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -535,7 +535,7 @@ if __name__ == "__main__":
 
     #  Deduplicate the test dataset
     deduper = Deduper(split_method=args.split_method, n_jobs=args.n_jobs)
-    deduper.deduplicate(corpus, id_column='doc_id', output_dir=output_dir)
+    deduper.deduplicate(corpus, id_column="doc_id", output_dir=output_dir)
 
     # *** Time taken to deduplicate DAGW with 16 cores, by `split_method` ***
     #   - 'none': ~3.5 minutes (found 24.75% duplicates)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -252,11 +252,7 @@ class Deduper:
         # If the corpus is a Dataset or IterableDataset then convert it to an
         # iterable of tuples
         if isinstance(corpus, Dataset) or isinstance(corpus, IterableDataset):
-            corpus = (
-                (sample["id"], sample["text"])
-                for sample in corpus
-                if sample["id"] not in [i for i, _ in self.mask]
-            )
+            corpus = ((sample["id"], sample["text"]) for sample in corpus)
 
         # Otherwise we check if the corpus is an iterable of dictionaries, in
         # which case we also convert it to an iterable of tuples
@@ -270,11 +266,7 @@ class Deduper:
             # If the first element of the corpus is a dictionary then we
             # convert the corpus to an iterable of tuples
             if isinstance(sample, dict):
-                corpus = (
-                    (sample["id"], sample["text"])
-                    for sample in corpus
-                    if sample["id"] not in [i for i, _ in self.mask]
-                )
+                corpus = ((sample["id"], sample["text"]) for sample in corpus)
 
         # Ensure that `output_dir` is a Path object
         output_dir = Path(output_dir)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -332,8 +332,7 @@ class Deduper:
         # If the corpus is a Dataset or IterableDataset then convert it to an
         # iterable of tuples
         if isinstance(corpus, Dataset) or isinstance(corpus, IterableDataset):
-            corpus = ((sample[id_column], sample[text_column])
-                      for sample in corpus)
+            corpus = ((sample[id_column], sample[text_column]) for sample in corpus)
 
         # Otherwise we check if the corpus is an iterable of dictionaries, in
         # which case we also convert it to an iterable of tuples
@@ -347,8 +346,7 @@ class Deduper:
             # If the first element of the corpus is a dictionary then we
             # convert the corpus to an iterable of tuples
             if isinstance(sample, dict):
-                corpus = ((sample[id_column], sample[text_column])
-                          for sample in corpus)
+                corpus = ((sample[id_column], sample[text_column]) for sample in corpus)
 
         # Ensure that `output_dir` is a Path object
         output_dir = Path(output_dir)
@@ -362,10 +360,12 @@ class Deduper:
                 raise FileExistsError(f"Output directory {output_dir} already exists.")
 
         # Create the output directory
-        if (store_corpus_to_disk or
-                store_lsh_cache_to_disk or
-                store_lsh_cache_to_disk or
-                store_config_to_disk):
+        if (
+            store_corpus_to_disk
+            or store_lsh_cache_to_disk
+            or store_lsh_cache_to_disk
+            or store_config_to_disk
+        ):
             output_dir.mkdir(parents=True)
 
         # Set up paths
@@ -530,12 +530,14 @@ if __name__ == "__main__":
 
     #  Deduplicate the test dataset
     deduper = Deduper(split_method=args.split_method, n_jobs=args.n_jobs)
-    deduper.deduplicate(corpus,
-                        output_dir=output_dir,
-                        store_mask_to_disk=False,
-                        store_corpus_to_disk=False,
-                        store_config_to_disk=False,
-                        store_lsh_cache_to_disk=False)
+    deduper.deduplicate(
+        corpus,
+        output_dir=output_dir,
+        store_mask_to_disk=False,
+        store_corpus_to_disk=False,
+        store_config_to_disk=False,
+        store_lsh_cache_to_disk=False,
+    )
 
     # *** Time taken to deduplicate DAGW with 16 cores, by `split_method` ***
     #   - 'none': ~3.5 minutes (found 24.75% duplicates)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -300,7 +300,10 @@ class Deduper:
         duplicates = 0
         num_processed = 0
         pbar_params = dict(
-            desc="Deduplicating", total=num_docs, disable=(not self.verbose)
+            desc="Deduplicating",
+            total=num_docs,
+            disable=(not self.verbose),
+            leave=False
         )
         with tqdm(batches, **pbar_params) as pbar:
 
@@ -380,7 +383,7 @@ class Deduper:
                     num_processed = new_num_processed
 
                     # Update the progress bar
-                    pbar.update(min(num_docs - pbar.n, batch_size))
+                    pbar.update(batch_size)
                     pct_duplicated = 100 * duplicates / num_processed
                     desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                     pbar.set_description(desc)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -493,10 +493,6 @@ class Deduper:
                             # Insert the document into the LSH cache
                             self.lsh_cache.insert(doc_idx, minhash)
 
-                            # Store the LSH cache to disk
-                            with lsh_cache_path.open("wb") as f:
-                                pickle.dump(self.lsh_cache, f)
-
                             # Store the non-duplicate document in the JSONL output
                             self._store_document(
                                 id=doc_idx, text=doc, output_path=output_path
@@ -517,6 +513,10 @@ class Deduper:
                         # Store the Boolean mask to disk
                         if store_mask:
                             self._store_document(output_path=mask_path, **mask_entry)
+
+                    # Store the LSH cache to disk
+                    with lsh_cache_path.open("wb") as f:
+                        pickle.dump(self.lsh_cache, f)
 
                     # Update the number of documents processed
                     num_processed += len(batch)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -313,15 +313,20 @@ class Deduper:
                                      num_minhashes=self.num_minhashes,
                                      random_seed=self.random_seed))
 
-                # Define parameters used in batch progress bars
-                pbar_params = dict(total=self.batch_size, leave=False)
-
                 # Iterate over the batches
                 for batch in pbar:
 
                     # Create a copy of the batch to ensure that we're not
                     # modifying the original
                     batch, batch_copy = it.tee(batch)
+
+                    # Compute size of the batch
+                    new_num_processed = num_processed + self.batch_size
+                    new_num_processed = min(new_num_processed, num_docs)
+                    batch_size = new_num_processed - num_processed
+
+                    # Define parameters used in batch progress bars
+                    pbar_params = dict(total=batch_size, leave=False)
 
                     # Compute the fingerprint for the document
                     pbar_params['desc'] = 'Computing minhashes'
@@ -372,9 +377,6 @@ class Deduper:
 
                     # Update the number of documents processed, and compute the
                     # number of documents in the batch
-                    new_num_processed = num_processed + self.batch_size
-                    new_num_processed = min(new_num_processed, num_docs)
-                    batch_size = new_num_processed - num_processed
                     num_processed = new_num_processed
 
                     # Update the progress bar

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -461,14 +461,14 @@ if __name__ == "__main__":
 
     # Remove the deduplicated corpus if it already exists
     if output_dir.exists():
-        output_dir.unlink()
+        shutil.rmtree(output_dir)
 
     # Load the test dataset
     corpus = load_dataset(
         "DDSC/partial-danish-gigaword-no-twitter",
         streaming=args.streaming,
         split="train",
-    )
+    ).rename_column('doc_id', 'id')
 
     #  Deduplicate the test dataset
     deduper = Deduper(split_method=args.split_method, n_jobs=args.n_jobs)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -393,8 +393,8 @@ class Deduper:
         # Return final update
         if self.verbose:
             print('Finished deduplicating corpus.')
-            print(f"- {num_processed:,} documents processed")
-            print(f"- {pct_duplicated:.2f}% documents marked as duplicates")
+            print(f"- {num_processed:,} documents processed.")
+            print(f"- {pct_duplicated:.2f}% documents marked as duplicates.")
 
 
 if __name__ == "__main__":

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -294,10 +294,12 @@ class Deduper:
 
     def deduplicate(
         self,
-        corpus: Union[Dataset,
-                      IterableDataset,
-                      Iterable[Tuple[Union[str, int], str]],
-                      Iterable[Dict[str, Union[str, int]]]],
+        corpus: Union[
+            Dataset,
+            IterableDataset,
+            Iterable[Tuple[Union[str, int], str]],
+            Iterable[Dict[str, Union[str, int]]],
+        ],
         output_dir: Union[str, Path] = "deduplicated",
         overwrite: bool = False,
         store_mask: bool = False,
@@ -330,8 +332,7 @@ class Deduper:
 
         # If the corpus is a Dataset or IterableDataset then convert it to an
         # iterable of tuples
-        if (isinstance(corpus, Dataset) or
-                isinstance(corpus, IterableDataset)):
+        if isinstance(corpus, Dataset) or isinstance(corpus, IterableDataset):
             corpus = (
                 (sample["id"], sample["text"])
                 for sample in corpus

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -526,18 +526,11 @@ if __name__ == "__main__":
         "DDSC/partial-danish-gigaword-no-twitter",
         streaming=args.streaming,
         split="train",
-    ).rename_column("doc_id", "id")
+    )
 
     #  Deduplicate the test dataset
     deduper = Deduper(split_method=args.split_method, n_jobs=args.n_jobs)
-    deduper.deduplicate(
-        corpus,
-        output_dir=output_dir,
-        store_mask_to_disk=False,
-        store_corpus_to_disk=False,
-        store_config_to_disk=False,
-        store_lsh_cache_to_disk=False,
-    )
+    deduper.deduplicate(corpus, id_column='doc_id', output_dir=output_dir)
 
     # *** Time taken to deduplicate DAGW with 16 cores, by `split_method` ***
     #   - 'none': ~3.5 minutes (found 24.75% duplicates)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -380,7 +380,7 @@ class Deduper:
                     num_processed = new_num_processed
 
                     # Update the progress bar
-                    pbar.update(batch_size)
+                    pbar.update(min(num_docs - pbar.n, batch_size))
                     pct_duplicated = 100 * duplicates / num_processed
                     desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                     pbar.set_description(desc)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -296,6 +296,7 @@ class Deduper:
         corpus: Union[Dataset, IterableDataset, Iterable[str]],
         output_dir: Union[str, Path] = "deduplicated",
         overwrite: bool = False,
+        store_mask: bool = False,
     ):
         """Removes duplicate documents from the corpus and stores it to disk.
 
@@ -308,6 +309,8 @@ class Deduper:
             overwrite (bool, optional):
                 Whether to overwrite the output file if it already exists.
                 Defaults to False.
+            store_mask (bool, optional):
+                Whether to store the mask to disk. Defaults to False.
 
         Raises:
             FileExistsError:
@@ -400,7 +403,8 @@ class Deduper:
                         self.mask.append(mask_entry)
 
                     # Store the Boolean mask to disk
-                    self._store_document(output_path=mask_path, **mask_entry)
+                    if store_mask:
+                        self._store_document(output_path=mask_path, **mask_entry)
 
                 # Get the maximal doc_idx in the batch
                 max_doc_idx = max(doc_idx for doc_idx, _ in batch)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -23,8 +23,7 @@ from unicodedata import normalize
 import re
 from tqdm.auto import tqdm
 import itertools as it
-
-from more_itertools import chunked
+import more_itertools as mit
 from joblib import Parallel, delayed
 import multiprocessing as mp
 import pickle
@@ -461,7 +460,7 @@ class Deduper:
             pickle.dump(config, f)
 
         #  Split the corpus into batches of `self.batch_size` documents
-        batches = chunked(corpus, self.batch_size)
+        batches = ichunked(corpus, self.batch_size)
 
         # Iterate over the corpus and store documents that are not duplicates
         duplicates = 0

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -27,6 +27,7 @@ import more_itertools as mit
 from joblib import Parallel, delayed
 import multiprocessing as mp
 import pickle
+from functools import partial
 
 
 def _get_shingles(doc: str,
@@ -472,7 +473,12 @@ class Deduper:
 
             # Initialise the multiprocessing
             with Parallel(n_jobs=self.n_jobs) as parallel:
-                fn = delayed(_get_minhash)
+                fn = delayed(partial(_get_minhash,
+                                     normalization_func=self.normalization_func,
+                                     split_method=self.split_method,
+                                     ngram_size=self.ngram_size,
+                                     num_minhashes=self.num_minhashes,
+                                     random_seed=self.random_seed))
 
                 # Iterate over the batches
                 for batch in pbar:

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -53,8 +53,8 @@ class Deduper:
             The number of MinHash functions to use. Defaults to 128.
         batch_size (int or None, optional):
             The number of documents to process at a time. If None then it is
-            set to 10,000 if `split_method` is 'paragraph', 'none' or None,
-            and 1,000 if `split_method` is 'word_ngram'. Defaults to None.
+            set to 100,000 if `split_method` is 'paragraph', 'none' or None,
+            and 10,000 if `split_method` is 'word_ngram'. Defaults to None.
         n_jobs (int, optional):
             The number of parallel jobs to use. If set to -1 then all available
             cores are used. Defaults to -1.
@@ -113,9 +113,9 @@ class Deduper:
 
         if batch_size is None:
             if self.split_method in ["paragraph", "none"] or self.split_method is None:
-                self.batch_size = 10_000
+                self.batch_size = 100_000
             elif self.split_method == "word_ngram":
-                self.batch_size = 1_000
+                self.batch_size = 10_000
             else:
                 raise ValueError(
                     f"Invalid split_method: {self.split_method}. "

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -148,10 +148,12 @@ class Deduper:
         # Create the Deduper
         deduper = cls(**config)
 
-        # Load the mask
-        with open(directory / "mask.jsonl", "r") as f:
-            mask = [json.loads(line) for line in f]
-        deduper.mask = mask
+        # Load the mask if it exists
+        mask_path = directory / "mask.jsonl"
+        if mask_path.exists():
+            with open(mask_path, "r") as f:
+                mask = [json.loads(line) for line in f]
+            deduper.mask = mask
 
         # Load the LSH cache
         with open(directory / "lsh_cache.pkl", "rb") as f:

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -315,6 +315,7 @@ class Deduper:
                         normalization_func=self.normalization_func,
                         split_method=self.split_method,
                         ngram_size=self.ngram_size,
+                        ngram_stride=self.ngram_stride,
                         num_minhashes=self.num_minhashes,
                         random_seed=self.random_seed,
                     )

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -483,12 +483,16 @@ class Deduper:
                 # Iterate over the batches
                 for batch in pbar:
 
+                    # Create a copy of the batch to ensure that we're not
+                    # modifying the original
+                    batch, batch_copy = it.tee(batch)
+
                     # Compute the fingerprint for the document
                     with tqdm(batch, total=self.batch_size, leave=False) as pb:
                         minhashes = parallel(fn(doc) for _, doc in pb)
 
                     # Iterate over the minhashes
-                    for (doc_idx, doc), minhash in zip(batch, minhashes):
+                    for (doc_idx, doc), minhash in zip(batch_copy, minhashes):
 
                         # If the document is not a near-duplicate candidate then
                         # store in the LSH cache and append it to the JSONL output

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -424,4 +424,4 @@ if __name__ == "__main__":
     # *** Time taken to deduplicate DAGW with 16 cores, by `split_method` ***
     #   - 'none': ~3.5 minutes (found 24.75% duplicates)
     #   - 'paragraph': ~4 minutes (found 25.83% duplicates)
-    #   - 'word_ngram' with n == 13: ~16 minutes (found 31.49% duplicates)
+    #   - 'word_ngram' with n == 13: ~10 minutes (found 25.77% duplicates)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -484,7 +484,8 @@ class Deduper:
                 for batch in pbar:
 
                     # Compute the fingerprint for the document
-                    minhashes = parallel(fn(doc) for _, doc in batch)
+                    with tqdm(batch, total=self.batch_size, leave=False) as pb:
+                        minhashes = parallel(fn(doc) for _, doc in pb)
 
                     # Iterate over the minhashes
                     for (doc_idx, doc), minhash in zip(batch, minhashes):
@@ -524,10 +525,10 @@ class Deduper:
                         pickle.dump(self.lsh_cache, f)
 
                     # Update the number of documents processed
-                    num_processed += len(batch)
+                    num_processed += self.batch_size
 
                     # Update the progress bar
-                    pbar.update(len(batch))
+                    pbar.update(self.batch_size)
                     pct_duplicated = 100 * duplicates / num_processed
                     desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                     pbar.set_description(desc)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -376,11 +376,15 @@ class Deduper:
                     with lsh_cache_path.open("wb") as f:
                         pickle.dump(self.lsh_cache, f)
 
-                    # Update the number of documents processed
-                    num_processed += self.batch_size
+                    # Update the number of documents processed, and compute the
+                    # number of documents in the batch
+                    new_num_processed = num_processed + self.batch_size
+                    new_num_processed = min(new_num_processed, num_docs)
+                    batch_size = new_num_processed - num_processed
+                    num_processed = new_num_processed
 
                     # Update the progress bar
-                    pbar.update(self.batch_size)
+                    pbar.update(batch_size)
                     pct_duplicated = 100 * duplicates / num_processed
                     desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                     pbar.set_description(desc)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -220,7 +220,7 @@ class Deduper:
         store_lsh_cache_to_disk: bool = True,
         store_config_to_disk: bool = True,
         return_generator: bool = False,
-    ):
+    ) -> Union[Iterable, None]:
         """Removes duplicate documents from the corpus.
 
         Args:
@@ -248,6 +248,11 @@ class Deduper:
             return_generator (bool, optional):
                 Whether to return a generator which yields the mask. Defaults
                 to False.
+
+        Returns:
+            Iterable or None:
+                If `return_generator` is True, then a generator which yields
+                a dictionary with keys `id` and `duplicate`. Otherwise, None.
 
         Raises:
             FileExistsError:

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -387,6 +387,7 @@ class Deduper:
 
         # Iterate over the corpus and store documents that are not duplicates
         duplicates = 0
+        num_processed = 0
         pbar_params = dict(
             desc="Deduplicating", total=num_docs, disable=(not self.verbose)
         )
@@ -435,12 +436,12 @@ class Deduper:
                     if store_mask:
                         self._store_document(output_path=mask_path, **mask_entry)
 
-                # Get the maximal doc_idx in the batch
-                max_doc_idx = max(doc_idx for doc_idx, _ in batch)
+                # Update the number of documents processed
+                num_processed += len(batch)
 
                 # Update the progress bar
                 pbar.update(len(batch))
-                pct_duplicated = 100 * duplicates / (1 + max_doc_idx)
+                pct_duplicated = 100 * duplicates / num_processed
                 desc = f"Deduplicating - {pct_duplicated:.2f}% near-duplicates found"
                 pbar.set_description(desc)
 

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -460,7 +460,7 @@ class Deduper:
             pickle.dump(config, f)
 
         #  Split the corpus into batches of `self.batch_size` documents
-        batches = ichunked(corpus, self.batch_size)
+        batches = mit.ichunked(corpus, self.batch_size)
 
         # Iterate over the corpus and store documents that are not duplicates
         duplicates = 0

--- a/src/dfm/cleaning/deduper_utils.py
+++ b/src/dfm/cleaning/deduper_utils.py
@@ -11,14 +11,24 @@ import re
 
 
 def get_shingles(doc: str,
-                  normalization_func: Callable,
-                  split_method: str,
-                  ngram_size: int) -> List[str]:
+                 normalization_func: Callable,
+                 split_method: str,
+                 ngram_size: int,
+                 ngram_stride: int) -> List[str]:
     """Extracts the shingles from a document.
 
     Args:
         doc (str):
             The document to extract the shingles from.
+        normalization_func (Callable):
+            The function to normalize the document with.
+        split_method (str):
+            The method to split the document into shingles.
+            Can be 'word_ngram', 'paragraph', 'none' or None.
+        ngram_size (int):
+            The size of the ngrams to use.
+        ngram_stride (int):
+            The stride of the ngrams to use.
 
     Returns:
         list of str:
@@ -51,15 +61,17 @@ def get_shingles(doc: str,
 
 
 def get_minhash(doc: str,
-                 normalization_func: Callable,
-                 split_method: str,
-                 ngram_size: int,
-                 num_minhashes: int,
-                 random_seed: int) -> LeanMinHash:
+                normalization_func: Callable,
+                split_method: str,
+                ngram_size: int,
+                ngram_stride: int,
+                num_minhashes: int,
+                random_seed: int) -> LeanMinHash:
     """Returns a minhash fingerprint for the given document.
 
     Args:
-        doc (str): The document to create the MinHash object for.
+        doc (str):
+            The document to create the MinHash object for.
 
     Returns:
         LeanMinHash: The minhash fingerprint for the given document.
@@ -73,7 +85,8 @@ def get_minhash(doc: str,
     shingles = get_shingles(doc,
                             normalization_func=normalization_func,
                             split_method=split_method,
-                            ngram_size=ngram_size)
+                            ngram_size=ngram_size,
+                            ngram_stride=ngram_stride)
 
     # Initialise the fingerprint
     minhash = MinHash(num_perm=num_minhashes, seed=random_seed)

--- a/src/dfm/cleaning/deduper_utils.py
+++ b/src/dfm/cleaning/deduper_utils.py
@@ -1,0 +1,103 @@
+"""Utility functions for the deduplicator.
+
+Author:
+    Dan Saattrup Nielsen (saattrupdan@gmail.com)
+"""
+
+from datasketch import MinHash, LeanMinHash
+from typing import List, Callable
+from unicodedata import normalize
+import re
+
+
+def get_shingles(doc: str,
+                  normalization_func: Callable,
+                  split_method: str,
+                  ngram_size: int) -> List[str]:
+    """Extracts the shingles from a document.
+
+    Args:
+        doc (str):
+            The document to extract the shingles from.
+
+    Returns:
+        list of str:
+            The shingles extracted from the document.
+
+    Raises:
+        ValueError:
+            If `split_method` is not 'word_ngram', 'paragraph', 'none'
+            or None.
+    """
+    # Normalise document
+    doc = normalization_func(doc)
+
+    # Extract shingles from the document, depending on the `split_method`
+    if split_method == "word_ngram":
+        words = [word for word in doc.split(" ") if len(word) > 0]
+        max_word_idx = 1 + len(words) - ngram_size
+        shingles = [
+            " ".join(words[i : i + ngram_size]).strip()
+            for i in range(0, max_word_idx, ngram_stride)
+        ] or [doc]
+    elif split_method == "paragraph":
+        shingles = [p for p in doc.split("\n") if len(p) > 0]
+    elif split_method == "none" or split_method is None:
+        shingles = [doc]
+    else:
+        raise ValueError(f"Invalid split method: {split_method}")
+
+    return shingles
+
+
+def get_minhash(doc: str,
+                 normalization_func: Callable,
+                 split_method: str,
+                 ngram_size: int,
+                 num_minhashes: int,
+                 random_seed: int) -> LeanMinHash:
+    """Returns a minhash fingerprint for the given document.
+
+    Args:
+        doc (str): The document to create the MinHash object for.
+
+    Returns:
+        LeanMinHash: The minhash fingerprint for the given document.
+
+    Raises:
+        ValueError:
+            If `split_method` is not 'word_ngram', 'paragraph', 'none'
+            or None.
+    """
+    # Extract shingles from the document, depending on the `split_method`
+    shingles = get_shingles(doc,
+                            normalization_func=normalization_func,
+                            split_method=split_method,
+                            ngram_size=ngram_size)
+
+    # Initialise the fingerprint
+    minhash = MinHash(num_perm=num_minhashes, seed=random_seed)
+
+    # Add all the shingles to the fingerprint
+    minhash.update_batch([shingle.encode("utf-8") for shingle in shingles])
+
+    # Convert the fingerprint to a LeanMinHash fingerprint, to save memory
+    # and increase performance
+    minhash = LeanMinHash(minhash, seed=random_seed)
+
+    # Return the fingerprint
+    return minhash
+
+
+def default_normalization(doc: str) -> str:
+    """NFKC normalise document and remove punctuation
+
+    Args:
+        doc (str): The document to normalize.
+
+    Returns:
+        str: The normalized document.
+    """
+    doc = normalize("NFKC", doc)
+    doc = re.sub(r"[\.\,\:\;\!\?\(\)\[\]\{\}]", " ", doc)
+    return re.sub(" +", " ", doc)

--- a/src/dfm/cleaning/deduper_utils.py
+++ b/src/dfm/cleaning/deduper_utils.py
@@ -10,11 +10,13 @@ from unicodedata import normalize
 import re
 
 
-def get_shingles(doc: str,
-                 normalization_func: Callable,
-                 split_method: str,
-                 ngram_size: int,
-                 ngram_stride: int) -> List[str]:
+def get_shingles(
+    doc: str,
+    normalization_func: Callable,
+    split_method: str,
+    ngram_size: int,
+    ngram_stride: int,
+) -> List[str]:
     """Extracts the shingles from a document.
 
     Args:
@@ -60,18 +62,33 @@ def get_shingles(doc: str,
     return shingles
 
 
-def get_minhash(doc: str,
-                normalization_func: Callable,
-                split_method: str,
-                ngram_size: int,
-                ngram_stride: int,
-                num_minhashes: int,
-                random_seed: int) -> LeanMinHash:
+def get_minhash(
+    doc: str,
+    normalization_func: Callable,
+    split_method: str,
+    ngram_size: int,
+    ngram_stride: int,
+    num_minhashes: int,
+    random_seed: int,
+) -> LeanMinHash:
     """Returns a minhash fingerprint for the given document.
 
     Args:
         doc (str):
             The document to create the MinHash object for.
+        normalization_func (Callable):
+            The function to normalize the document with.
+        split_method (str):
+            The method to split the document into shingles.
+            Can be 'word_ngram', 'paragraph', 'none' or None.
+        ngram_size (int):
+            The size of the ngrams to use.
+        ngram_stride (int):
+            The stride of the ngrams to use.
+        num_minhashes (int):
+            The number of minhashes to use.
+        random_seed (int):
+            The random seed to use.
 
     Returns:
         LeanMinHash: The minhash fingerprint for the given document.
@@ -82,11 +99,13 @@ def get_minhash(doc: str,
             or None.
     """
     # Extract shingles from the document, depending on the `split_method`
-    shingles = get_shingles(doc,
-                            normalization_func=normalization_func,
-                            split_method=split_method,
-                            ngram_size=ngram_size,
-                            ngram_stride=ngram_stride)
+    shingles = get_shingles(
+        doc,
+        normalization_func=normalization_func,
+        split_method=split_method,
+        ngram_size=ngram_size,
+        ngram_stride=ngram_stride,
+    )
 
     # Initialise the fingerprint
     minhash = MinHash(num_perm=num_minhashes, seed=random_seed)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -1,6 +1,7 @@
 """Tests for the deduplication module"""
 
 from dfm.cleaning import Deduper
+from dfm.cleaning.deduper_utils import get_shingles
 import tempfile
 from pathlib import Path
 import json
@@ -156,15 +157,15 @@ class TestDeduper:
         assert miss <= 30
 
     def test_2_ngram_shingles(self):
-        shingles = self.deduper(ngram_size=2)._get_shingles("Hej med dig Kim")
+        shingles = get_shingles("Hej med dig Kim", ngram_size=2)
         assert shingles == ["Hej med", "med dig", "dig Kim"]
 
     def test_3_ngram_shingles(self):
-        shingles = self.deduper(ngram_size=3)._get_shingles("Hej med dig Kim")
+        shingles = get_shingles("Hej med dig Kim", ngram_size=3)
         assert shingles == ["Hej med dig", "med dig Kim"]
 
     def test_double_stride_shingles(self):
-        shingles = self.deduper(ngram_stride=2)._get_shingles("Hej med dig Kim")
+        shingles = get_shingles("Hej med dig Kim", ngram_size=1, ngram_stride=2)
         assert shingles == ["Hej", "dig"]
 
     def test_get_config(self):

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -38,9 +38,7 @@ class TestDeduper:
     def shingle_params(self):
         yield dict(
             normalization_func=default_normalization,
-            split_method="word_ngram",
-            num_minhashes=128,
-            random_seed=42,
+            split_method="word_ngram"
         )
 
     def deduper(self, **kwargs):

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -36,10 +36,12 @@ def identity_fn(doc: str) -> str:
 class TestDeduper:
     @pytest.fixture(scope="class")
     def shingle_params(self):
-        yield dict(normalization_func=normalization_func,
-                   split=method='word_ngram',
-                   num_minhashes=128,
-                   random_seed=42)
+        yield dict(
+            normalization_func=normalization_func,
+            split_method="word_ngram",
+            num_minhashes=128,
+            random_seed=42,
+        )
 
     def deduper(self, **kwargs):
         default_test_args = dict(ngram_size=1, random_seed=42, verbose=False)
@@ -165,24 +167,21 @@ class TestDeduper:
         assert miss <= 30
 
     def test_2_ngram_shingles(self, shingle_params):
-        shingles = get_shingles("Hej med dig Kim",
-                                ngram_size=2,
-                                ngram_stride=1,
-                                **shingle_params)
+        shingles = get_shingles(
+            "Hej med dig Kim", ngram_size=2, ngram_stride=1, **shingle_params
+        )
         assert shingles == ["Hej med", "med dig", "dig Kim"]
 
     def test_3_ngram_shingles(self, shingle_params):
-        shingles = get_shingles("Hej med dig Kim",
-                                ngram_size=3,
-                                ngram_stride=1,
-                                **shingle_params)
+        shingles = get_shingles(
+            "Hej med dig Kim", ngram_size=3, ngram_stride=1, **shingle_params
+        )
         assert shingles == ["Hej med dig", "med dig Kim"]
 
     def test_double_stride_shingles(self, shingle_params):
-        shingles = get_shingles("Hej med dig Kim",
-                                ngram_size=1,
-                                ngram_stride=2,
-                                **shingle_params)
+        shingles = get_shingles(
+            "Hej med dig Kim", ngram_size=1, ngram_stride=2, **shingle_params
+        )
         assert shingles == ["Hej", "dig"]
 
     def test_get_config(self):

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -218,6 +218,6 @@ class TestDeduper:
             assert new_deduper.mask != deduper.mask
 
             # Test that the loaded LSH cache works as intended
-            minhash = get_minhash(corpus[0], **minhash_params)
+            minhash = get_minhash(corpus[0][1], **minhash_params)
             assert len(loaded_deduper.lsh_cache.query(minhash)) > 0
             assert len(new_deduper.lsh_cache.query(minhash)) == 0

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -37,6 +37,12 @@ class TestDeduper:
         return Deduper(**dict(default_test_args, **kwargs))
 
     def dedup(self, corpus, **kwargs):
+
+        # Add a document ID to the corpus, if it isn't there already
+        if isinstance(corpus, list) and isinstance(corpus[0], str):
+            corpus = list(enumerate(corpus))
+
+        # Deduplicate the corpus and return it
         with tempfile.TemporaryDirectory() as temp:
             deduper = self.deduper(**kwargs)
             deduper.deduplicate(corpus, output_dir=temp, overwrite=True)
@@ -169,6 +175,7 @@ class TestDeduper:
 
     def test_load_from_disk(self):
         corpus = ["hej med dig min ven", "hej med dig min ven", "farvel du gamle"]
+        corpus = list(enumerate(corpus))
         with tempfile.TemporaryDirectory() as temp:
 
             # Create a deduper loaded from disk, and a different new one

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -203,9 +203,7 @@ class TestDeduper:
 
             # Create a deduper loaded from disk, and a different new one
             deduper = self.deduper(split_method="paragraph")
-            deduper.deduplicate(
-                corpus, output_dir=temp, overwrite=True
-            )
+            deduper.deduplicate(corpus, output_dir=temp, overwrite=True)
             loaded_deduper = Deduper.load_from_disk(temp)
             new_deduper = self.deduper()
 

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -36,10 +36,7 @@ def identity_fn(doc: str) -> str:
 class TestDeduper:
     @pytest.fixture(scope="class")
     def shingle_params(self):
-        yield dict(
-            normalization_func=default_normalization,
-            split_method="word_ngram"
-        )
+        yield dict(normalization_func=default_normalization, split_method="word_ngram")
 
     def deduper(self, **kwargs):
         default_test_args = dict(ngram_size=1, random_seed=42, verbose=False)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -42,7 +42,7 @@ class TestDeduper:
     def minhash_params(self):
         yield dict(
             normalization_func=default_normalization,
-            split_method="word_ngram",
+            split_method="paragraph",
             ngram_size=1,
             ngram_stride=1,
             num_minhashes=128,

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -192,7 +192,9 @@ class TestDeduper:
 
             # Create a deduper loaded from disk, and a different new one
             deduper = self.deduper(split_method="paragraph")
-            deduper.deduplicate(corpus, output_dir=temp, overwrite=True)
+            deduper.deduplicate(corpus,
+                                output_dir=temp, overwrite=True,
+                                store_mask=True)
             loaded_deduper = Deduper.load_from_disk(temp)
             new_deduper = self.deduper()
 

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -204,7 +204,7 @@ class TestDeduper:
             # Create a deduper loaded from disk, and a different new one
             deduper = self.deduper(split_method="paragraph")
             deduper.deduplicate(
-                corpus, output_dir=temp, overwrite=True, store_mask=True
+                corpus, output_dir=temp, overwrite=True
             )
             loaded_deduper = Deduper.load_from_disk(temp)
             new_deduper = self.deduper()

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -1,7 +1,7 @@
 """Tests for the deduplication module"""
 
 from dfm.cleaning import Deduper
-from dfm.cleaning.deduper_utils import get_shingles, normalization_func
+from dfm.cleaning.deduper_utils import get_shingles, default_normalization
 import tempfile
 from pathlib import Path
 import json
@@ -37,7 +37,7 @@ class TestDeduper:
     @pytest.fixture(scope="class")
     def shingle_params(self):
         yield dict(
-            normalization_func=normalization_func,
+            normalization_func=default_normalization,
             split_method="word_ngram",
             num_minhashes=128,
             random_seed=42,


### PR DESCRIPTION
This changes the Deduper in the following two ways:

1. Added the `store_mask` argument to the `deduplicate` method, which now defaults to `False`. If `True` this will stream the mask to disk, as well as storing it in the `mask` attribute.
2. The `deduplicate` method now only accepts input which already have document IDs in them, and uses these IDs rather than merely enumerating the corpus. Thus, the method now requires `corpus` to be a) a Dataset with an `id` and `text` column, b) an IterableDataset with an `id` and `text` column, c) an iterable of dictionaries, each of which have an `id` and `text` entry, or d) an iterable of tuples `(doc_id, text)`. These will all be converted into an iterable of tuples in the code.
3. Moved `_get_minhash` and `_get_shingles` functions to separate script, `deduper_utils.py`. Moving them out of the class was required to ensure that they were pickleable, as this was required by the multiprocessing.
4. Now handles batches in a purely iterable fashion, which ensures that we don't have to load in an entire batch in memory every time. Aside from requiring less memory, thus enabling larger batch sizes (upped them by 10x now), the script also runs faster.
5. Added internal progress bars, related to the computing of minhashes and the batch deduplication. These are turned off if `verbose` is `False`, just like the main progress bars.
6. Now saves the LSH cache after each batch, rather than after every iteration, as this slowed down the deduplication significantly. This means that resuming deduplication will be lossy, but only with respect to the last batch.