### PR TITLE
fix: Deal with `num_docs` when corpus is an iterable

### DIFF
--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -424,7 +424,8 @@ class Deduper:
 
                     # Compute size of the batch
                     new_num_processed = num_processed + self.batch_size
-                    new_num_processed = min(new_num_processed, num_docs)
+                    if num_docs is not None:
+                        new_num_processed = min(new_num_processed, num_docs)
                     batch_size = new_num_processed - num_processed
 
                     # Define parameters used in batch progress bars
@@ -502,7 +503,7 @@ class Deduper:
 
         # Return final update
         if self.verbose:
-            pct_duplicated = 100 * duplicates / num_docs
+            pct_duplicated = 100 * duplicates / num_processed
             print("Finished deduplicating corpus.")
             print(f"- {num_processed:,} documents processed.")
             print(f"- {pct_duplicated:.2f}% documents marked as duplicates.")

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -79,6 +79,12 @@ class TestDeduper:
                 misses += 1
         return (100.0 * misses) / iterations
 
+    def test_stream(self):
+        corpus = iter([(0, 'hej med dig min ven'),
+                       (1, 'hej med dig'),
+                       (2, 'farvel du gamle')])
+        self.dedup(corpus) == ['hej med dig min ven', 'farvel du gamle']
+
     def test_removes_exact_duplicates(self):
         assert self.dedup(
             ["hej med dig min ven", "hej med dig min ven", "farvel du gamle"]

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -80,10 +80,10 @@ class TestDeduper:
         return (100.0 * misses) / iterations
 
     def test_stream(self):
-        corpus = iter([(0, 'hej med dig min ven'),
-                       (1, 'hej med dig'),
-                       (2, 'farvel du gamle')])
-        self.dedup(corpus) == ['hej med dig min ven', 'farvel du gamle']
+        corpus = iter(
+            [(0, "hej med dig min ven"), (1, "hej med dig"), (2, "farvel du gamle")]
+        )
+        self.dedup(corpus) == ["hej med dig min ven", "farvel du gamle"]
 
     def test_removes_exact_duplicates(self):
         assert self.dedup(


### PR DESCRIPTION
This was an issue when the corpus was an iterable, as `num_docs` would be `None` in that case.