### PR TITLE
Fix/dedup mask saving

### DIFF
--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,4 +18,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@21.12b0
+      - uses: psf/black@stable
+          version: "21.12b0"

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -19,4 +19,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
           version: "21.12b0"

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@21.12b0
+      - uses: psf/black@stable
         with:
-          version: "21.12b0"
+          version: "22.3.0"

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: pallets/click
+        with:
+          version: "7.1.2"
       - uses: psf/black@stable
         with:
           version: "21.12b0"

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: jpetrucciani/black-check@21.12b0

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black-check@21.12b0
+      - uses: psf/black@21.12b0

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,9 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pallets/click
-        with:
-          version: "7.1.2"
-      - uses: psf/black@stable
+      - uses: psf/black@21.12b0
         with:
           version: "21.12b0"

--- a/.github/workflows/black_formatter.yml
+++ b/.github/workflows/black_formatter.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jpetrucciani/black-check@21.12b0
+      - uses: psf/black-check@21.12b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ more_itertools~=8.12.0
 # utility
 wasabi~=0.9.0
 pydantic~=1.8.2
-click~=7.1.2
+click~=8.0.4
 
 # testing
 pytest>=6.2.5
@@ -29,4 +29,4 @@ pytest-lazy-fixture>=0.6.3
 pytest-cov>=2.8.1
 
 # format
-black==21.12b0
+black==22.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ more_itertools~=8.12.0
 # utility
 wasabi~=0.9.0
 pydantic~=1.8.2
+click~=7.1.2
 
 # testing
 pytest>=6.2.5
@@ -28,4 +29,4 @@ pytest-lazy-fixture>=0.6.3
 pytest-cov>=2.8.1
 
 # format
-black==22.1.0
+black==21.12b0

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -370,7 +370,7 @@ class Deduper:
                 # Store existing mask
                 if self.save_mask and store_mask_to_disk:
                     mask_path = output_dir / "mask.jsonl"
-                    mask_str = '\n'.join(json.dumps(sample) for sample in self.mask)
+                    mask_str = "\n".join(json.dumps(sample) for sample in self.mask)
                     with mask_path.open("w") as f:
                         f.write(mask_str)
 
@@ -388,12 +388,14 @@ class Deduper:
                         pickle.dump(config, f)
 
             else:
-                raise FileExistsError(f"Output directory {output_dir} already exists."
-                                      "Please set `overwrite` to True to overwrite "
-                                      "the files. If you are loading an existing "
-                                      "Deduper from the directory then the previous "
-                                      "config, mask and LSH cache will still will "
-                                      "not be lost and will be stored in the directory.")
+                raise FileExistsError(
+                    f"Output directory {output_dir} already exists."
+                    "Please set `overwrite` to True to overwrite "
+                    "the files. If you are loading an existing "
+                    "Deduper from the directory then the previous "
+                    "config, mask and LSH cache will still will "
+                    "not be lost and will be stored in the directory."
+                )
 
         # Create the output directory
         if (

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -398,7 +398,7 @@ class Deduper:
                 )
 
         # Create the output directory
-        if (
+        if not output_dir.exists() and (
             store_corpus_to_disk
             or store_lsh_cache_to_disk
             or store_mask_to_disk

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -360,15 +360,46 @@ class Deduper:
         # is False and otherwise delete the file
         if output_dir.exists():
             if overwrite:
+
+                # Delete the output directory
                 shutil.rmtree(output_dir)
+
+                # Create the output directory
+                output_dir.mkdir(parents=True)
+
+                # Store existing mask
+                if self.save_mask and store_mask_to_disk:
+                    mask_path = output_dir / "mask.jsonl"
+                    mask_str = '\n'.join(json.dumps(sample) for sample in self.mask)
+                    with mask_path.open("w") as f:
+                        f.write(mask_str)
+
+                # Store existing LSH cache
+                if store_lsh_cache_to_disk:
+                    lsh_cache_path = output_dir / "lsh_cache.pkl"
+                    with lsh_cache_path.open("wb") as f:
+                        pickle.dump(self.lsh_cache, f)
+
+                # Store existing configuration
+                if store_config_to_disk:
+                    config_path = output_dir / "config.pkl"
+                    config = self.get_config()
+                    with config_path.open("wb") as f:
+                        pickle.dump(config, f)
+
             else:
-                raise FileExistsError(f"Output directory {output_dir} already exists.")
+                raise FileExistsError(f"Output directory {output_dir} already exists."
+                                      "Please set `overwrite` to True to overwrite "
+                                      "the files. If you are loading an existing "
+                                      "Deduper from the directory then the previous "
+                                      "config, mask and LSH cache will still will "
+                                      "not be lost and will be stored in the directory.")
 
         # Create the output directory
         if (
             store_corpus_to_disk
             or store_lsh_cache_to_disk
-            or store_lsh_cache_to_disk
+            or store_mask_to_disk
             or store_config_to_disk
         ):
             output_dir.mkdir(parents=True)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -109,17 +109,14 @@ class TestDeduper:
         ) == ["Hej med dig", "Gå din vej"]
 
     def test_split_by_word_ngram(self):
-        assert (
-            self.dedup(
-                [
-                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                    "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                ],
-                split_method="word_ngram",
-                ngram_size=5,
-            )
-            == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
-        )
+        assert self.dedup(
+            [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+            ],
+            split_method="word_ngram",
+            ngram_size=5,
+        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
 
     def test_split_by_paragraph(self):
         assert self.dedup(
@@ -158,16 +155,13 @@ class TestDeduper:
         ]
 
     def test_aggresive_normalization(self):
-        assert (
-            self.dedup(
-                [
-                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                    "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!",
-                ],
-                normalization_func=word_shape,
-            )
-            == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
-        )
+        assert self.dedup(
+            [
+                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!",
+            ],
+            normalization_func=word_shape,
+        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
 
     def test_2_minhashes(self):
         miss = self.miss_percentage(num_minhashes=2)

--- a/tests/cleaning/deduper_test.py
+++ b/tests/cleaning/deduper_test.py
@@ -109,14 +109,17 @@ class TestDeduper:
         ) == ["Hej med dig", "Gå din vej"]
 
     def test_split_by_word_ngram(self):
-        assert self.dedup(
-            [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-            ],
-            split_method="word_ngram",
-            ngram_size=5,
-        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+        assert (
+            self.dedup(
+                [
+                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                    "Er kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                ],
+                split_method="word_ngram",
+                ngram_size=5,
+            )
+            == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+        )
 
     def test_split_by_paragraph(self):
         assert self.dedup(
@@ -155,13 +158,16 @@ class TestDeduper:
         ]
 
     def test_aggresive_normalization(self):
-        assert self.dedup(
-            [
-                "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
-                "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!",
-            ],
-            normalization_func=word_shape,
-        ) == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+        assert (
+            self.dedup(
+                [
+                    "Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!",
+                    "Den var jo typisk påtrængende pæn og overrasket:\n et, tu! et, tu!",
+                ],
+                normalization_func=word_shape,
+            )
+            == ["Der kom en soldat marcherende hen ad landevejen:\n én, to! én, to!"]
+        )
 
     def test_2_minhashes(self):
         miss = self.miss_percentage(num_minhashes=2)

--- a/tests/cleaning/quality_test.py
+++ b/tests/cleaning/quality_test.py
@@ -4,6 +4,7 @@ from typing import List
 
 from dfm.cleaning import QualityFilter
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 
 class TestQualityFilter:
@@ -118,7 +119,7 @@ class TestQualityFilter:
     @pytest.mark.parametrize(
         "texts,expected",
         [
-            (pytest.lazy_fixture("bullets_texts"), False),
+            (lazy_fixture("bullets_texts"), False),
             (["56789okd23456789098765sds"], True),
         ],
     )


### PR DESCRIPTION
This saves the current configuration, mask and LSH cache to disk when `overwrite` is True. This means that when an existing deduper is loaded with `load_from_disk` then it's possible to continue appending to the previous file.