### PR TITLE
Fixed workflow error leading workflow always passing

### DIFF
--- a/.github/workflows/Dependabot.yml
+++ b/.github/workflows/Dependabot.yml
@@ -1,0 +1,22 @@
+# Configuration: https://dependabot.com/docs/config-file/
+# Docs: https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically
+
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: ":arrow_up:"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: ":arrow_up:"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run and write pytest
       run: |
         pip install --editable .
-        python -m  pytest --cov=src/dfm --cov-report term-missing | tee pytest-coverage.txt
+        pytest --cov=src/dfm --cov-report term-missing
 
 
   pytest-coverage:
@@ -51,7 +51,8 @@ jobs:
     - name: Run and write pytest
       run: |
         pip install --editable .
-        python -m  pytest --cov=src/dfm --cov-report term-missing | tee pytest-coverage.txt
+        set -o pipefail
+        pytest --cov=src/dfm --cov-report term-missing | tee pytest-coverage.txt
     - name: Pytest coverage comment
       id: coverage-comment
       uses: MishaKav/pytest-coverage-comment@v1.1.20


### PR DESCRIPTION
1) Fixed workflow error leading to workflow always passing due to the pipe preventing the raised error.
2) Removed unused pipes.
3) Added Dependabot to keep dependencies up to date.