### PR TITLE
patch memory issue caused by tee

### DIFF
--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -410,6 +410,7 @@ class Deduper:
         else:
 
             # extract the first element of the corpus
+            corpus = iter(corpus)
             sample = next(corpus)
             # and add it back in
             corpus = it.chain([sample], corpus)

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -409,11 +409,11 @@ class Deduper:
         # which case we also convert it to an iterable of tuples
         else:
 
-            # Create a copy of the corpus to ensure that we're not modifying
-            # the original, and extract the first element of the copy.
-            corpus, corpus_copy = it.tee(corpus)
-            sample = next(corpus_copy)
-
+            # extract the first element of the corpus
+            sample = next(corpus)
+            # and add it back in
+            corpus = it.chain([sample], corpus)
+            
             # If the first element of the corpus is a dictionary then we
             # convert the corpus to an iterable of tuples
             if isinstance(sample, dict):

--- a/src/dfm/cleaning/deduper.py
+++ b/src/dfm/cleaning/deduper.py
@@ -413,7 +413,7 @@ class Deduper:
             sample = next(corpus)
             # and add it back in
             corpus = it.chain([sample], corpus)
-            
+
             # If the first element of the corpus is a dictionary then we
             # convert the corpus to an iterable of tuples
             if isinstance(sample, dict):


### PR DESCRIPTION
Patched memory issue caused by the tee operator.

The deduplication script seems to have a large memory overhead, which isn't halved (as would have been expected) by reducing the `num_min_hash` from 128 -> 64. From this post [here](https://stackoverflow.com/questions/69754473/implicit-memory-consumption-with-itertools-tee-of-generators). It seems like the tee operator has to be emptied otherwise the duplicate is kept in memory.

This solution removed the `tee` and extract the first element for the corpus iterator to normalize the iterator, then add it back if using `itertools.chain`
