### PR TITLE
chore: Add pre-commits

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile = black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,9 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.7.0
+    rev: 5.10.1
     hooks:
     -   id: isort
-        args: [--style black]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 22.3.0
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    - id: flake8
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+    -   id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-    - id: flake8
 -   repo: https://github.com/timothycrosley/isort
     rev: 5.7.0
     hooks:
     -   id: isort
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 5.7.0
     hooks:
     -   id: isort
+        args: [--style black]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ The dataset currently available to the project for training:
 | ------------------ | ------------------------------------------------------------------------ | ---------------------- |--------------
 | :books: DAGW       | Danish Gigaword. A wide coverage dataset of Danish text.                 | \~1 000 (\~?)              | ✅
 | :bird: HopeTwitter | A dataset of tweets collected as a part of the HOPE project.             | ~973 (~463)                       | ✅
-| :newspaper: DaNews | A dataset consisting of Danish newspapers                                | ~9 296 (~8 667)                      | 
+| :newspaper: DaNews | A dataset consisting of Danish newspapers                                | ~9 296 (~8 667)                      |
 | 🗯 Reddit-da        | A Danish subsection of reddit                                            | ~86                   | ✅
-| :link: Netarkivet  | A subsection of the "Danish" internet collected the royal Danish library | ~400 000 (~130 000)                    | 
+| :link: Netarkivet  | A subsection of the "Danish" internet collected the royal Danish library | ~400 000 (~130 000)                    |
 | :link: mC4         | A cleaned part of the common crawl                                       |                        | ✅
-| Lex.dk             | A Danish curated wikipedia, written by experts                           | ~26                    | 
-| **Sum**             |                                                                          | ~11 381 (~9 130)                    | 
+| Lex.dk             | A Danish curated wikipedia, written by experts                           | ~26                    |
+| **Sum**             |                                                                          | ~11 381 (~9 130)                    |
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,14 +3,14 @@ wandb~=0.12.9
 # models
 transformers~=4.16.0
 torch>=1.6.0,<=1.11.0
-protobuf==3.20.1
+protobuf>=3.20.1,<=3.21.0
 
 # tokenizers
-tokenizers==0.10.1
+tokenizers>=0.10.1,<0.11.0
 
 # data
 datasets>=2.0.0,<2.3.0
-ndjson==0.3.1
+ndjson>=0.3.1,<0.4.0
 
 ## data cleaning
 spacy>=3.1.4,<3.4.0
@@ -26,10 +26,10 @@ click~=8.0.4
 pre-commit~=2.17.0
 
 # testing
-pytest>=6.2.5
-pytest-lazy-fixture>=0.6.3
-pytest-cov>=2.8.1
+pytest>=6.2.5,<6.3.0
+pytest-lazy-fixture>=0.6.3,<0.7.0
+pytest-cov>=2.8.1,<2.9.0
 
 # format
-black==22.3.0
+black>=22.3.0,<22.4.0
 isort~=5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ pytest-cov>=2.8.1
 
 # format
 black==22.3.0
+isort~=5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pandas>=1.0.0,<2.0.0
 wasabi>=0.9.0,<0.10.0
 pydantic~=1.8.2
 click~=8.0.4
+pre-commit~=2.17.0
 
 # testing
 pytest>=6.2.5
@@ -31,4 +32,3 @@ pytest-cov>=2.8.1
 
 # format
 black==22.3.0
-


### PR DESCRIPTION
Adds the following pre-commit hooks:

- `black`: Stylistic changes and linting
- `flake8`: Linting
- `isort`: Ordering of imports

Note that the pre-commit hooks have to be installed using `pre-commit install`, and during the first commit all the hooks will be installed, so it will take a few seconds longer than normal - after that, it's instantaneous.