### PR TITLE
update dolma dependency to newest version, contains fix for dolma stat command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.10"
 dependencies = [
   "pydantic>=2.4.2", # dolma does not work with very old versions of pydantic
   "datasets>=2.4.0",
-  "dolma@git+https://github.com/allenai/dolma.git@5a010a2685914b1db7744426abfb4b9ece52da95", # Install from git until a 0.9.2 package is released
+  "dolma[pii,code]@git+https://github.com/allenai/dolma.git@28727302a34225f4ce70ce97940cb18ad9a91583", # Install from git until a 0.9.2 package is released
   "kenlm>=0.2.0", # Used for perplexity tagging
   "blingfire>=0.1.8", # Used for perplexity tagging
   "requests>=2.31.0",


### PR DESCRIPTION
Also add the optional dependencies for pii (personally identifiable information) tagger and code tagger.