### PR TITLE
Update docling version to fix error when reading docx files

### DIFF
--- a/data-processing/pyproject.toml
+++ b/data-processing/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "nlp_dedup",
   "datatrove>=0.2.0",
   "pyyaml",
-  "docling>=1.20.0",
+  "docling>=2.7.1",
   "joblib>=1.4.2",
   "pdfminer-six>=20240706",
   "pypandoc-binary>=1.14",


### PR DESCRIPTION
Problems with reading docx files using docling have been fixed in 2.7.1.
So updating the pyproject.toml to reflect that. 