### PR TITLE
Add Munin 1.0 release note

### DIFF
--- a/da/docs/index.md
+++ b/da/docs/index.md
@@ -139,6 +139,23 @@ hide:
   color: #c8102e;
 }
 
+.story-card-featured {
+  margin: 2rem 0 0;
+  border-top: none;
+  padding: 2rem;
+}
+
+.story-card-featured .story-card-title {
+  font-size: 1.6rem;
+  line-height: 1.2;
+  margin-bottom: 0.75rem;
+}
+
+.story-card-featured .story-card-desc {
+  max-width: 56rem;
+  font-size: 0.98rem;
+}
+
 .story-card-more {
   background: transparent;
   box-shadow: none;
@@ -262,6 +279,11 @@ hide:
   <h1>Vi bygger fundamentet for dansk AI</h1>
   <p>Sprogmodeller er blevet kritisk infrastruktur — men mindre sprog som dansk risikerer at blive efterladt. Danish Foundation Models er et samarbejde på tværs af danske universiteter og forskningsinstitutioner om at udvikle, evaluere og tilpasse sprog-AI til gavn for det danske samfund.</p>
 </div>
+
+<a class="story-card story-card-featured" href="./news/2026/06/11/munin-10-udgivelsesnote.html">
+  <span class="story-card-title">Munin 1.0-udgivelsesnote</span>
+  <span class="story-card-desc">En familie af danskfokuserede post-trænede sprogmodeller bygget oven på stærke åbne basismodeller.</span>
+</a>
 
 <div class="pillars">
   <div class="pillar">

--- a/da/docs/news/posts/munin-10-udgivelsesnote.md
+++ b/da/docs/news/posts/munin-10-udgivelsesnote.md
@@ -1,0 +1,168 @@
+---
+draft: false
+date: 2026-06-11
+slug: munin-10-udgivelsesnote
+tags:
+  - Modeludgivelse
+---
+
+# Munin 1.0-udgivelsesnote
+
+<p class="dfm-post-byline"><strong>Forfattere:</strong> Rasmus Larsen, Torben Blach – Alexandra Instituttet A/S</p>
+
+I dag udgiver Danish Foundation Models [Munin 1.0-familien af sprogmodeller](https://huggingface.co/collections/danish-foundation-models/munin-10), som er post-trænet oven på nogle af de stærkeste åbne modeller i deres klasse. Modellerne er trænet på en kombination af eksisterende åbne og nyudviklede datasæt.
+
+<!-- more -->
+
+## Modeller og resultater
+
+Munin 1.0-familien er post-trænet på modeller med åbne vægte fra [Swiss AI](https://huggingface.co/swiss-ai), [Mistral](https://huggingface.co/mistralai) og [Qwen](https://huggingface.co/Qwen). Alle basismodellerne er oprindeligt udgivet under [Apache 2.0-licensen](https://www.apache.org/licenses/LICENSE-2.0), og vores modeller har samme licens.
+
+| Udvikler | Basismodel | Munin-model | Land | Åbenhed |
+| --- | --- | --- | --- | --- |
+| Swiss AI | [`swiss-ai/Apertus-8B-2509`](https://huggingface.co/swiss-ai/Apertus-8B-2509) | [`munin-apertus-8b`](https://huggingface.co/danish-foundation-models/munin-apertus-8b) | Europa/Schweiz | Fuldt åben |
+| Mistral | [`mistralai/Ministral-3-8B-Base-2512`](https://huggingface.co/mistralai/Ministral-3-8B-Base-2512) | [`munin-ministral3-8B`](https://huggingface.co/danish-foundation-models/munin-ministral3-8B) | Europa/Frankrig | Åbne vægte |
+| Qwen 3.5 9B | [`Qwen/Qwen3.5-9B-Base`](https://huggingface.co/Qwen/Qwen3.5-9B-Base) | [`munin-qwen3.5-9B`](https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B) | Kina | Åbne vægte |
+
+Munin 1.0 er en tekstbaseret post-træningsudgivelse, så sammenligningerne nedenfor fokuserer på tekstbenchmarks. Nogle af de oprindelige instruktionsmodeller har billede-til-tekst eller andre multimodale evner, men de evner understøttes ikke af de modeller, der udgives her.
+
+Vi evaluerer Munin-modellerne mod de instruktions-tunede modeller udgivet af de oprindelige modeludviklere. Da Munin er trænet fra de samme basismodeller, er det en direkte sammenligning af to uafhængige post-træningsindsatser: den oprindelige udviklers post-træning og vores danskfokuserede Munin-træning.
+
+De aggregerede resultater nedenfor er uvægtede gennemsnit på tværs af evalueringer i hver opgavegruppe. Scores er procenter, og standardfejl er procentpoint. Blå markerer den bedste Original/Munin-score inden for hver modelfamilie, eller begge hvis de er lige gode inden for usikkerheden. Fed skrift markerer scores, der ikke er signifikant under den bedste score i rækken. Se de [fulde benchmarkresultater](/news/results/munin-10-full-results.html) for de enkelte evalueringer bag hvert aggregat.
+
+<div class="md-typeset__table dfm-eval-table-wrap">
+  <table class="dfm-eval-table">
+    <caption>Aggregerede opgavescores</caption>
+    <thead>
+      <tr>
+        <th scope="col" rowspan="2">Suite</th>
+        <th scope="col" rowspan="2">Opgave</th>
+        <th scope="col" rowspan="2">Metrik</th>
+        <th scope="col" colspan="2">Apertus 8B</th>
+        <th scope="col" colspan="2">Ministral 8B</th>
+        <th scope="col" colspan="2">Qwen 9B</th>
+      </tr>
+      <tr>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="dfm-suite-start dfm-suite-danish hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original"><td>Dansk</td><td>Common-sense Reasoning</td><td>MCC</td><td>33,1 ± 0,9</td><td>29,4 ± 1,3</td><td>52,4 ± 1,2</td><td>50,2 ± 1,3</td><td><strong>64,6 ± 0,7</strong></td><td>62,2 ± 0,9</td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Grammatical Error Detection</td><td>micro-F1</td><td><strong>18,0 ± 1,3</strong></td><td><strong>17,4 ± 1,1</strong></td><td><strong>21,7 ± 2,0</strong></td><td><strong>17,7 ± 0,7</strong></td><td><strong>20,4 ± 1,2</strong></td><td><strong>20,7 ± 1,1</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-munin hl-qwen-original"><td>Dansk</td><td>Instruction-following</td><td>Accuracy</td><td>69,0 ± 1,1</td><td>51,4 ± 1,4</td><td>66,7 ± 1,3</td><td>74,4 ± 0,9</td><td><strong>81,6 ± 0,8</strong></td><td>77,9 ± 0,9</td></tr>
+      <tr class="dfm-suite-danish hl-apertus-munin hl-ministral-original hl-qwen-munin"><td>Dansk</td><td>Knowledge</td><td>MCC</td><td>58,9 ± 0,7</td><td>62,3 ± 0,7</td><td>73,6 ± 0,5</td><td>68,5 ± 0,6</td><td>76,0 ± 0,5</td><td><strong>77,6 ± 0,5</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Linguistic Acceptability</td><td>MCC</td><td>33,0 ± 1,2</td><td>29,3 ± 2,4</td><td>43,4 ± 1,9</td><td>18,9 ± 3,1</td><td><strong>49,2 ± 1,7</strong></td><td><strong>52,2 ± 1,3</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Multiple-choice Reading Comprehension</td><td>MCC</td><td>67,1 ± 1,0</td><td>66,0 ± 2,0</td><td><strong>85,9 ± 1,4</strong></td><td><strong>84,4 ± 1,1</strong></td><td><strong>87,2 ± 1,2</strong></td><td><strong>87,3 ± 1,3</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Named Entity Recognition</td><td>micro-F1</td><td>49,3 ± 1,4</td><td>47,6 ± 1,3</td><td>61,1 ± 1,0</td><td>51,4 ± 1,8</td><td><strong>69,1 ± 1,2</strong></td><td><strong>69,6 ± 1,2</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-munin hl-qwen-munin"><td>Dansk</td><td>Natural Language Inference</td><td>MCC</td><td>48,8 ± 2,3</td><td>52,1 ± 2,6</td><td>25,8 ± 1,6</td><td>58,2 ± 2,2</td><td>53,8 ± 1,9</td><td><strong>65,6 ± 2,0</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Reading Comprehension</td><td>F1</td><td><strong>70,8 ± 0,5</strong></td><td>69,4 ± 0,6</td><td>69,7 ± 0,7</td><td><strong>71,2 ± 0,8</strong></td><td><strong>70,8 ± 0,6</strong></td><td><strong>72,0 ± 0,7</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Sentiment Classification</td><td>MCC</td><td>57,9 ± 1,0</td><td>54,3 ± 1,1</td><td>60,4 ± 1,0</td><td>59,6 ± 1,4</td><td><strong>64,9 ± 0,9</strong></td><td><strong>64,7 ± 1,0</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Summarization</td><td>chrF++</td><td><strong>37,6 ± 0,2</strong></td><td>36,9 ± 0,2</td><td>35,1 ± 0,3</td><td>37,0 ± 0,2</td><td>36,5 ± 0,3</td><td><strong>36,7 ± 0,4</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Dansk</td><td>Word-in-Context</td><td>MCC</td><td>11,8 ± 2,2</td><td>8,7 ± 3,5</td><td>29,9 ± 1,7</td><td>23,3 ± 3,2</td><td><strong>44,6 ± 2,1</strong></td><td><strong>40,1 ± 3,5</strong></td></tr>
+      <tr class="dfm-suite-start dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-original"><td>Engelsk</td><td>Common-sense Reasoning</td><td>Accuracy</td><td>58,7 ± 0,5</td><td>23,2 ± 0,4</td><td>73,1 ± 0,4</td><td>59,6 ± 0,5</td><td><strong>90,0 ± 0,3</strong></td><td>85,7 ± 0,3</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original"><td>Engelsk</td><td>Instruction-following</td><td>Accuracy</td><td>73,3 ± 1,9</td><td>54,7 ± 2,0</td><td>70,4 ± 1,8</td><td>69,8 ± 1,9</td><td><strong>89,6 ± 1,5</strong></td><td>78,6 ± 1,8</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-munin"><td>Engelsk</td><td>Knowledge</td><td>Accuracy</td><td>50,3 ± 0,5</td><td>41,9 ± 0,5</td><td><strong>81,7 ± 0,3</strong></td><td>73,0 ± 0,3</td><td>79,2 ± 0,2</td><td><strong>82,4 ± 0,2</strong></td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original"><td>Engelsk</td><td>Long-context</td><td>Accuracy</td><td>34,6 ± 2,1</td><td>35,8 ± 2,1</td><td>51,4 ± 2,2</td><td>49,4 ± 2,2</td><td><strong>67,2 ± 2,1</strong></td><td>54,6 ± 2,2</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-original"><td>Engelsk</td><td>Math</td><td>Accuracy</td><td>68,1 ± 1,3</td><td>56,7 ± 1,4</td><td>92,2 ± 0,7</td><td>82,3 ± 1,1</td><td><strong>94,8 ± 0,6</strong></td><td>92,2 ± 0,7</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Engelsk</td><td>Truthfulness</td><td>Accuracy</td><td>16,8 ± 1,3</td><td>15,7 ± 1,3</td><td>64,7 ± 1,7</td><td>63,3 ± 1,7</td><td><strong>78,1 ± 1,4</strong></td><td><strong>74,2 ± 1,5</strong></td></tr>
+      <tr class="dfm-suite-start dfm-suite-agentic hl-apertus-original hl-ministral-original hl-qwen-original"><td>Agentisk</td><td>Code</td><td>pass@1</td><td>46,8 ± 2,5</td><td>39,2 ± 2,4</td><td>75,0 ± 2,1</td><td>49,2 ± 2,3</td><td><strong>83,0 ± 1,8</strong></td><td>77,2 ± 2,1</td></tr>
+      <tr class="dfm-suite-agentic hl-apertus-original hl-ministral-original hl-qwen-original"><td>Agentisk</td><td>Tool Calling</td><td>Accuracy</td><td>52,4 ± 0,8</td><td>43,1 ± 0,8</td><td>75,0 ± 0,7</td><td>49,2 ± 0,8</td><td><strong>79,4 ± 0,6</strong></td><td>75,8 ± 0,7</td></tr>
+    </tbody>
+  </table>
+</div>
+
+??? info "Hvad indgår i hvert aggregat?"
+
+    De danske opgavegrupper følger EuroEvals danske opgavetaksonomi. Links peger på artikler, hvor de findes, ellers på offentlige datasæt, upstream-repositorier eller de EuroEval-scripts, der bruges til at konstruere benchmarkdatasættet. For flere entries, der ender på `-da`, går linket til artiklen for det oprindelige benchmark, fordi den evaluerede ressource er en dansk oversat eller på anden måde lokaliseret variant. Nogle danske varianter, herunder `ifeval-da`, er tilpasninger snarere end simple direkte oversættelser.
+
+    | Suite | Aggregeret opgave | Benchmarks |
+    | --- | --- | --- |
+    | Dansk | Common-sense Reasoning | [`goldenswag-da`](https://arxiv.org/abs/2504.07825), [`hellaswag-da`](https://arxiv.org/abs/1905.07830), [`winogrande-da`](https://arxiv.org/abs/1907.10641) |
+    | Dansk | Grammatical Error Detection | [`gerlangmod-da`](https://github.com/noahmanu/gerlangmod) |
+    | Dansk | Instruction-following | [`ifeval-da`](https://arxiv.org/abs/2311.07911) |
+    | Dansk | Knowledge | [`arc-da`](https://arxiv.org/abs/1803.05457), [`dameta`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark), [`danish-citizen-tests`](https://huggingface.co/datasets/alexandrainst/danish-citizen-tests), [`danske-talemaader`](https://huggingface.co/datasets/Juunge/danske-talemaader), [`mmlu-da`](https://arxiv.org/abs/2009.03300) |
+    | Dansk | Linguistic Acceptability | [`dala`](https://arxiv.org/abs/2512.04799), [`scala-da`](https://arxiv.org/abs/2304.00906) |
+    | Dansk | Multiple-choice Reading Comprehension | [`belebele-da`](https://arxiv.org/abs/2308.16884) |
+    | Dansk | Named Entity Recognition | [`dane`](https://arxiv.org/abs/2107.05295), [`dansk`](https://arxiv.org/abs/2402.18209) |
+    | Dansk | Natural Language Inference | [`danish-entailment`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark), [`danish-lexical-inference`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | Dansk | Reading Comprehension | [`multi-wiki-qa-da`](https://arxiv.org/abs/2509.04111), [`scandiqa-da`](https://arxiv.org/abs/2304.00906) |
+    | Dansk | Sentiment Classification | [`angry-tweets`](https://huggingface.co/datasets/DDSC/angry-tweets), [`danish-sentiment-in-context`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | Dansk | Summarization | [`nordjylland-news`](https://huggingface.co/datasets/alexandrainst/nordjylland-news-summarization) |
+    | Dansk | Word-in-Context | [`danwic`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | Engelsk | Knowledge | [`ARC-C`](https://arxiv.org/abs/1803.05457), [`ARC-E`](https://arxiv.org/abs/1803.05457), [`MMLU`](https://arxiv.org/abs/2009.03300), [`MMLU-Pro`](https://arxiv.org/abs/2406.01574) |
+    | Engelsk | Other task groups | [`HellaSwag`](https://arxiv.org/abs/1905.07830), [`IFEval`](https://arxiv.org/abs/2311.07911), [`RULER 32k`](https://arxiv.org/abs/2404.06654), [`GSM8K`](https://arxiv.org/abs/2110.14168), [`TruthfulQA`](https://arxiv.org/abs/2109.07958) |
+    | Agentisk | Code and Tool Calling | [`HumanEval`](https://arxiv.org/abs/2107.03374), [`MBPP p@1`](https://arxiv.org/abs/2108.07732), [`BFCL`](https://arxiv.org/abs/2407.07770) |
+
+Hovedresultatet er, at Munin er stærkt konkurrencedygtig på de danske evalueringer, og at vores post-trænede modeller i flere opgavegrupper matcher eller forbedrer de oprindelige instruktionsmodeller. De stærkeste resultater er på dansk Knowledge, Reading Comprehension, Summarization og Natural Language Inference, hvor nogle Munin-modeller ligger foran selv med usikkerheden taget i betragtning. Dermed kan det ses at post-træningen flytter modellerne mod stærkere dansk performance, samtidig med at de bevarer en brugbar generel kapabilitetsprofil.
+
+Resultaterne på engelsk og agentiske opgaver er mere blandede. De oprindelige instruktionsmodeller er generelt stærkere på kode, værktøjskald og flere engelske benchmarks, hvilket afspejler, at Munin 1.0 nu primært fokuserer på danske tekstkapabiliteter. De forskelle er vigtige, fordi de peger direkte på næste fase af arbejdet: at bevare de danske forbedringer, samtidig med at der investeres mere målrettet i reasoning, multilingvalitet og agentiske kapabiliteter.
+
+Vi kørte også en fokuseret dansk turnering i kreativ skrivning på tværs af 360 bedømte kampe, vurderet af Qwen3.5-397B-A17B. Vi valgte denne dommer på grund af dens stærke dansksproglige evner.
+
+Turneringen er ikke et bredt benchmark for modelkvalitet, men den er nyttig, fordi kreativ skrivning er en dansk opgave med højt signal: Den tester sproglig flydendehed, register, kohærens, og om modellen kan producere tekst, der føles naturlig frem for blot korrekt. [Munin Qwen 9B](https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B) skiller sig tydeligt ud fra resten af feltet med en 96-9 rekord, mens [Munin Apertus 8B](https://huggingface.co/danish-foundation-models/munin-apertus-8b) placerer sig som nummer to, og [Munin Ministral 8B](https://huggingface.co/danish-foundation-models/munin-ministral3-8B) også slår sin oprindelige modpart.
+
+<div class="md-typeset__table">
+  <table class="dfm-tournament-table">
+    <caption>Rangering i dansk kreativ skriveturnering; V-T er samlet vundet-tabt</caption>
+    <thead>
+      <tr>
+        <th scope="col">Placering</th>
+        <th scope="col">Model</th>
+        <th scope="col">V-T</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="dfm-model-munin">
+        <td>1</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B">Munin Qwen 9B</a></strong></td>
+        <td>96-9</td>
+      </tr>
+      <tr class="dfm-model-munin">
+        <td>2</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-apertus-8b">Munin Apertus 8B</a></strong></td>
+        <td>56-45</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Original Qwen 9B</td>
+        <td>43-53</td>
+      </tr>
+      <tr class="dfm-model-munin">
+        <td>4</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-ministral3-8B">Munin Ministral 8B</a></strong></td>
+        <td>43-54</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Original Apertus 8B</td>
+        <td>30-65</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td>Original Ministral 8B</td>
+        <td>26-68</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Bidragydere
+
+Rasmus Larsen ledte træningen, udførte eksperimenter, byggede syntetiske datasæt og benchmarks, og skrev udkastet til udgivelsesannonceringen.
+
+Oliver Kinch byggede syntetiske datasæt og benchmarks.
+
+Vladimir Salnikov og Jacob Nielsen bidrog til datasæt.
+
+Dan Saattrup Smart udviklede benchmarks og ledte integrationen i EuroEval.
+
+Torben Blach bidrog med projektledelse og koordinering.
+
+## Anerkendelser
+
+Arbejdet blev støttet af Danish Foundation Models-projektet, finansieret af den danske regering. Arbejdet blev delvist støttet af DeiC National HPC (grant agreement DeiC-SDU-N5-2025162).

--- a/en/docs/_static/extra.css
+++ b/en/docs/_static/extra.css
@@ -34,3 +34,216 @@
   --md-accent-fg-color--transparent: rgba(200, 16, 46, 0.1);
   --md-typeset-a-color: #c8102e;
 }
+
+.dfm-post-byline {
+  margin-top: -0.4rem;
+  margin-bottom: 1.2rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.dfm-eval-table-wrap {
+  overflow-x: auto;
+  width: 100%;
+  max-width: 100%;
+}
+
+.dfm-eval-table {
+  width: 100%;
+  min-width: 0;
+  table-layout: fixed;
+  font-size: 0.58rem;
+  line-height: 1.18;
+}
+
+.dfm-eval-table caption {
+  caption-side: top;
+  margin-bottom: 0.4rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.7rem;
+  text-align: left;
+}
+
+.dfm-eval-table th {
+  background: #f4f7fb;
+  color: #4b5563;
+  font-weight: 700;
+  text-align: center;
+  vertical-align: middle;
+  padding: 0.34rem 0.24rem;
+}
+
+.dfm-eval-table td {
+  padding: 0.28rem 0.22rem;
+  vertical-align: middle;
+}
+
+.dfm-eval-table th:nth-child(1),
+.dfm-eval-table td:nth-child(1) {
+  width: 7%;
+}
+
+.dfm-eval-table td:nth-child(2) {
+  width: 23%;
+  font-weight: 700;
+  hyphens: auto;
+  overflow-wrap: anywhere;
+}
+
+.dfm-eval-table th:nth-child(3),
+.dfm-eval-table td:nth-child(3) {
+  width: 7%;
+  color: #6b7280;
+  text-align: center;
+}
+
+.dfm-eval-table td:nth-child(n+4) {
+  width: 10.5%;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.dfm-eval-table thead tr:first-child th:nth-child(4),
+.dfm-eval-table thead tr:first-child th:nth-child(5),
+.dfm-eval-table thead tr:first-child th:nth-child(6),
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(1),
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(3),
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(5),
+.dfm-eval-table tbody td:nth-child(4),
+.dfm-eval-table tbody td:nth-child(6),
+.dfm-eval-table tbody td:nth-child(8) {
+  border-left: 0.08rem solid #d9dee7;
+}
+
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(2),
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(4),
+.dfm-eval-table thead tr:nth-child(2) th:nth-child(6),
+.dfm-eval-table tbody td:nth-child(5),
+.dfm-eval-table tbody td:nth-child(7),
+.dfm-eval-table tbody td:nth-child(9) {
+  border-left: 0.05rem solid #eef1f5;
+}
+
+.dfm-eval-table .dfm-suite-start td {
+  border-top: 0.11rem solid #687385;
+}
+
+.dfm-eval-table .dfm-suite-danish td:first-child {
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.dfm-eval-table .dfm-suite-english td:first-child {
+  color: #374151;
+  font-weight: 700;
+}
+
+.dfm-eval-table .dfm-suite-agentic td:first-child {
+  color: #7c3aed;
+  font-weight: 700;
+}
+
+.dfm-eval-table .hl-apertus-original td:nth-child(4),
+.dfm-eval-table .hl-apertus-munin td:nth-child(5),
+.dfm-eval-table .hl-ministral-original td:nth-child(6),
+.dfm-eval-table .hl-ministral-munin td:nth-child(7),
+.dfm-eval-table .hl-qwen-original td:nth-child(8),
+.dfm-eval-table .hl-qwen-munin td:nth-child(9) {
+  background: #dcecff;
+  background-clip: padding-box;
+  box-shadow: inset 0 0 0 0.18rem var(--md-default-bg-color);
+}
+
+@media screen and (max-width: 76.1875em) {
+  .dfm-eval-table {
+    font-size: 0.48rem;
+  }
+
+  .dfm-eval-table th {
+    padding: 0.22rem 0.12rem;
+  }
+
+  .dfm-eval-table td {
+    padding: 0.2rem 0.1rem;
+  }
+
+  .dfm-eval-table th:nth-child(1),
+  .dfm-eval-table td:nth-child(1) {
+    width: 7.5%;
+  }
+
+  .dfm-eval-table td:nth-child(2) {
+    width: 22.5%;
+  }
+
+  .dfm-eval-table th:nth-child(3),
+  .dfm-eval-table td:nth-child(3) {
+    width: 7%;
+  }
+
+  .dfm-eval-table td:nth-child(n+4) {
+    width: 10.5%;
+  }
+}
+
+.dfm-tournament-table {
+  width: 100%;
+  max-width: 42rem;
+  table-layout: fixed;
+  font-size: 0.72rem;
+  line-height: 1.25;
+}
+
+.dfm-tournament-table caption {
+  caption-side: top;
+  margin-bottom: 0.4rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.7rem;
+  text-align: left;
+}
+
+.dfm-tournament-table th {
+  background: #f4f7fb;
+  color: #4b5563;
+  font-weight: 700;
+  padding: 0.42rem 0.5rem;
+  vertical-align: middle;
+}
+
+.dfm-tournament-table td {
+  padding: 0.42rem 0.5rem;
+  vertical-align: middle;
+}
+
+.dfm-tournament-table th:nth-child(1),
+.dfm-tournament-table td:nth-child(1) {
+  width: 18%;
+  text-align: center;
+}
+
+.dfm-tournament-table th:nth-child(2),
+.dfm-tournament-table td:nth-child(2) {
+  width: 58%;
+}
+
+.dfm-tournament-table th:nth-child(3),
+.dfm-tournament-table td:nth-child(3) {
+  width: 24%;
+  text-align: center;
+}
+
+.dfm-tournament-table th:nth-child(2),
+.dfm-tournament-table th:nth-child(3),
+.dfm-tournament-table td:nth-child(2),
+.dfm-tournament-table td:nth-child(3) {
+  border-left: 0.08rem solid #d9dee7;
+}
+
+.dfm-tournament-table tr.dfm-model-munin td:nth-child(2) {
+  background: #dcecff;
+  background-clip: padding-box;
+  box-shadow: inset 0 0 0 0.18rem var(--md-default-bg-color);
+  color: #1d4ed8;
+  font-weight: 700;
+}

--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -139,6 +139,23 @@ hide:
   color: #c8102e;
 }
 
+.story-card-featured {
+  margin: 2rem 0 0;
+  border-top: none;
+  padding: 2rem;
+}
+
+.story-card-featured .story-card-title {
+  font-size: 1.6rem;
+  line-height: 1.2;
+  margin-bottom: 0.75rem;
+}
+
+.story-card-featured .story-card-desc {
+  max-width: 56rem;
+  font-size: 0.98rem;
+}
+
 .story-card-more {
   background: transparent;
   box-shadow: none;
@@ -262,6 +279,11 @@ hide:
   <h1>Building the Foundation of Danish AI</h1>
   <p>Language models have become critical infrastructure — but smaller languages like Danish risk being left behind. Danish Foundation Models is a collaborative effort across Danish universities and research institutions to develop, evaluate, and adapt open language AI that serves Danish society.</p>
 </div>
+
+<a class="story-card story-card-featured" href="./news/2026/06/11/munin-10-release-note.html">
+  <span class="story-card-title">Munin 1.0 release note</span>
+  <span class="story-card-desc">A family of Danish-focused post-trained language models built on top of strong open base models.</span>
+</a>
 
 <div class="pillars">
   <div class="pillar">

--- a/en/docs/news/posts/munin-10-release-note.md
+++ b/en/docs/news/posts/munin-10-release-note.md
@@ -1,0 +1,168 @@
+---
+draft: false
+date: 2026-06-11
+slug: munin-10-release-note
+tags:
+  - Model Release
+---
+
+# Munin 1.0 release note
+
+<p class="dfm-post-byline"><strong>Authors:</strong> Rasmus Larsen, Torben Blach – Alexandra Instituttet A/S</p>
+
+Today, Danish Foundation Models releases the [Munin 1.0 family of language models](https://huggingface.co/collections/danish-foundation-models/munin-10), post-trained on top of several best-in-class open models. These models are trained using a combination of existing open and newly developed datasets.
+
+<!-- more -->
+
+## Models and results
+
+The Munin 1.0 family of models are post-trained on open-weights models from [Swiss AI](https://huggingface.co/swiss-ai), [Mistral](https://huggingface.co/mistralai), and [Qwen](https://huggingface.co/Qwen). All models were originally released under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0), and our models have the same license.
+
+| Developer | Base model | Munin model | Country | Openness |
+| --- | --- | --- | --- | --- |
+| Swiss AI | [`swiss-ai/Apertus-8B-2509`](https://huggingface.co/swiss-ai/Apertus-8B-2509) | [`munin-apertus-8b`](https://huggingface.co/danish-foundation-models/munin-apertus-8b) | Europe/Switzerland | Fully open |
+| Mistral | [`mistralai/Ministral-3-8B-Base-2512`](https://huggingface.co/mistralai/Ministral-3-8B-Base-2512) | [`munin-ministral3-8B`](https://huggingface.co/danish-foundation-models/munin-ministral3-8B) | Europe/France | Open weights |
+| Qwen 3.5 9B | [`Qwen/Qwen3.5-9B-Base`](https://huggingface.co/Qwen/Qwen3.5-9B-Base) | [`munin-qwen3.5-9B`](https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B) | China | Open weights |
+
+Munin 1.0 is a text-only post-training release, so the comparisons below focus on text benchmarks. Some upstream instruct models advertise image-to-text or other multimodal capabilities, but those capabilities are not supported by the models released here.
+
+We evaluated the Munin models against the instruction-tuned models released by the original model developers. Since Munin is trained from the same base models, this is an apples-to-apples comparison of two independent post-training efforts: the original developer's post-training and our Danish-focused Munin training.
+
+The aggregate scores below are unweighted means across evaluations in each task group. Scores are percentages, and standard errors are percentage points. Blue marks the better Original/Munin score within each model family, or both if they are tied within uncertainty. Bold scores are not substantially below the row-best score. See the [full benchmark results](../results/munin-10-full-results.md) for the individual evaluations behind each aggregate.
+
+<div class="md-typeset__table dfm-eval-table-wrap">
+  <table class="dfm-eval-table">
+    <caption>Task aggregate scores</caption>
+    <thead>
+      <tr>
+        <th scope="col" rowspan="2">Suite</th>
+        <th scope="col" rowspan="2">Task</th>
+        <th scope="col" rowspan="2">Metric</th>
+        <th scope="col" colspan="2">Apertus 8B</th>
+        <th scope="col" colspan="2">Ministral 8B</th>
+        <th scope="col" colspan="2">Qwen 9B</th>
+      </tr>
+      <tr>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+        <th scope="col">Original</th>
+        <th scope="col">Munin</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="dfm-suite-start dfm-suite-danish hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original"><td>Danish</td><td>Common-sense Reasoning</td><td>MCC</td><td>33.1 ± 0.9</td><td>29.4 ± 1.3</td><td>52.4 ± 1.2</td><td>50.2 ± 1.3</td><td><strong>64.6 ± 0.7</strong></td><td>62.2 ± 0.9</td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Grammatical Error Detection</td><td>micro-F1</td><td><strong>18.0 ± 1.3</strong></td><td><strong>17.4 ± 1.1</strong></td><td><strong>21.7 ± 2.0</strong></td><td><strong>17.7 ± 0.7</strong></td><td><strong>20.4 ± 1.2</strong></td><td><strong>20.7 ± 1.1</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-munin hl-qwen-original"><td>Danish</td><td>Instruction-following</td><td>Accuracy</td><td>69.0 ± 1.1</td><td>51.4 ± 1.4</td><td>66.7 ± 1.3</td><td>74.4 ± 0.9</td><td><strong>81.6 ± 0.8</strong></td><td>77.9 ± 0.9</td></tr>
+      <tr class="dfm-suite-danish hl-apertus-munin hl-ministral-original hl-qwen-munin"><td>Danish</td><td>Knowledge</td><td>MCC</td><td>58.9 ± 0.7</td><td>62.3 ± 0.7</td><td>73.6 ± 0.5</td><td>68.5 ± 0.6</td><td>76.0 ± 0.5</td><td><strong>77.6 ± 0.5</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Linguistic Acceptability</td><td>MCC</td><td>33.0 ± 1.2</td><td>29.3 ± 2.4</td><td>43.4 ± 1.9</td><td>18.9 ± 3.1</td><td><strong>49.2 ± 1.7</strong></td><td><strong>52.2 ± 1.3</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Multiple-choice Reading Comprehension</td><td>MCC</td><td>67.1 ± 1.0</td><td>66.0 ± 2.0</td><td><strong>85.9 ± 1.4</strong></td><td><strong>84.4 ± 1.1</strong></td><td><strong>87.2 ± 1.2</strong></td><td><strong>87.3 ± 1.3</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Named Entity Recognition</td><td>micro-F1</td><td>49.3 ± 1.4</td><td>47.6 ± 1.3</td><td>61.1 ± 1.0</td><td>51.4 ± 1.8</td><td><strong>69.1 ± 1.2</strong></td><td><strong>69.6 ± 1.2</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-munin hl-qwen-munin"><td>Danish</td><td>Natural Language Inference</td><td>MCC</td><td>48.8 ± 2.3</td><td>52.1 ± 2.6</td><td>25.8 ± 1.6</td><td>58.2 ± 2.2</td><td>53.8 ± 1.9</td><td><strong>65.6 ± 2.0</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Reading Comprehension</td><td>F1</td><td><strong>70.8 ± 0.5</strong></td><td>69.4 ± 0.6</td><td>69.7 ± 0.7</td><td><strong>71.2 ± 0.8</strong></td><td><strong>70.8 ± 0.6</strong></td><td><strong>72.0 ± 0.7</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Sentiment Classification</td><td>MCC</td><td>57.9 ± 1.0</td><td>54.3 ± 1.1</td><td>60.4 ± 1.0</td><td>59.6 ± 1.4</td><td><strong>64.9 ± 0.9</strong></td><td><strong>64.7 ± 1.0</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Summarization</td><td>chrF++</td><td><strong>37.6 ± 0.2</strong></td><td>36.9 ± 0.2</td><td>35.1 ± 0.3</td><td>37.0 ± 0.2</td><td>36.5 ± 0.3</td><td><strong>36.7 ± 0.4</strong></td></tr>
+      <tr class="dfm-suite-danish hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>Danish</td><td>Word-in-Context</td><td>MCC</td><td>11.8 ± 2.2</td><td>8.7 ± 3.5</td><td>29.9 ± 1.7</td><td>23.3 ± 3.2</td><td><strong>44.6 ± 2.1</strong></td><td><strong>40.1 ± 3.5</strong></td></tr>
+      <tr class="dfm-suite-start dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-original"><td>English</td><td>Common-sense Reasoning</td><td>Accuracy</td><td>58.7 ± 0.5</td><td>23.2 ± 0.4</td><td>73.1 ± 0.4</td><td>59.6 ± 0.5</td><td><strong>90.0 ± 0.3</strong></td><td>85.7 ± 0.3</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-ministral-munin hl-qwen-original"><td>English</td><td>Instruction-following</td><td>Accuracy</td><td>73.3 ± 1.9</td><td>54.7 ± 2.0</td><td>70.4 ± 1.8</td><td>69.8 ± 1.9</td><td><strong>89.6 ± 1.5</strong></td><td>78.6 ± 1.8</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-munin"><td>English</td><td>Knowledge</td><td>Accuracy</td><td>50.3 ± 0.5</td><td>41.9 ± 0.5</td><td><strong>81.7 ± 0.3</strong></td><td>73.0 ± 0.3</td><td>79.2 ± 0.2</td><td><strong>82.4 ± 0.2</strong></td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original"><td>English</td><td>Long-context</td><td>Accuracy</td><td>34.6 ± 2.1</td><td>35.8 ± 2.1</td><td>51.4 ± 2.2</td><td>49.4 ± 2.2</td><td><strong>67.2 ± 2.1</strong></td><td>54.6 ± 2.2</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-ministral-original hl-qwen-original"><td>English</td><td>Math</td><td>Accuracy</td><td>68.1 ± 1.3</td><td>56.7 ± 1.4</td><td>92.2 ± 0.7</td><td>82.3 ± 1.1</td><td><strong>94.8 ± 0.6</strong></td><td>92.2 ± 0.7</td></tr>
+      <tr class="dfm-suite-english hl-apertus-original hl-apertus-munin hl-ministral-original hl-ministral-munin hl-qwen-original hl-qwen-munin"><td>English</td><td>Truthfulness</td><td>Accuracy</td><td>16.8 ± 1.3</td><td>15.7 ± 1.3</td><td>64.7 ± 1.7</td><td>63.3 ± 1.7</td><td><strong>78.1 ± 1.4</strong></td><td><strong>74.2 ± 1.5</strong></td></tr>
+      <tr class="dfm-suite-start dfm-suite-agentic hl-apertus-original hl-ministral-original hl-qwen-original"><td>Agentic</td><td>Code</td><td>pass@1</td><td>46.8 ± 2.5</td><td>39.2 ± 2.4</td><td>75.0 ± 2.1</td><td>49.2 ± 2.3</td><td><strong>83.0 ± 1.8</strong></td><td>77.2 ± 2.1</td></tr>
+      <tr class="dfm-suite-agentic hl-apertus-original hl-ministral-original hl-qwen-original"><td>Agentic</td><td>Tool Calling</td><td>Accuracy</td><td>52.4 ± 0.8</td><td>43.1 ± 0.8</td><td>75.0 ± 0.7</td><td>49.2 ± 0.8</td><td><strong>79.4 ± 0.6</strong></td><td>75.8 ± 0.7</td></tr>
+    </tbody>
+  </table>
+</div>
+
+??? info "What is included in each aggregate?"
+
+    Danish task groupings follow the EuroEval Danish task taxonomy. Links point to papers where available, otherwise to public datasets, upstream repositories, or the EuroEval dataset construction scripts used for the benchmark. For several entries ending in `-da`, the link is to the original benchmark paper because the evaluated resource is a Danish translated or otherwise localized variant. Some Danish variants, including `ifeval-da`, are adaptations rather than simple direct translations.
+
+    | Suite | Aggregate task | Benchmarks |
+    | --- | --- | --- |
+    | Danish | Common-sense Reasoning | [`goldenswag-da`](https://arxiv.org/abs/2504.07825), [`hellaswag-da`](https://arxiv.org/abs/1905.07830), [`winogrande-da`](https://arxiv.org/abs/1907.10641) |
+    | Danish | Grammatical Error Detection | [`gerlangmod-da`](https://github.com/noahmanu/gerlangmod) |
+    | Danish | Instruction-following | [`ifeval-da`](https://arxiv.org/abs/2311.07911) |
+    | Danish | Knowledge | [`arc-da`](https://arxiv.org/abs/1803.05457), [`dameta`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark), [`danish-citizen-tests`](https://huggingface.co/datasets/alexandrainst/danish-citizen-tests), [`danske-talemaader`](https://huggingface.co/datasets/Juunge/danske-talemaader), [`mmlu-da`](https://arxiv.org/abs/2009.03300) |
+    | Danish | Linguistic Acceptability | [`dala`](https://arxiv.org/abs/2512.04799), [`scala-da`](https://arxiv.org/abs/2304.00906) |
+    | Danish | Multiple-choice Reading Comprehension | [`belebele-da`](https://arxiv.org/abs/2308.16884) |
+    | Danish | Named Entity Recognition | [`dane`](https://arxiv.org/abs/2107.05295), [`dansk`](https://arxiv.org/abs/2402.18209) |
+    | Danish | Natural Language Inference | [`danish-entailment`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark), [`danish-lexical-inference`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | Danish | Reading Comprehension | [`multi-wiki-qa-da`](https://arxiv.org/abs/2509.04111), [`scandiqa-da`](https://arxiv.org/abs/2304.00906) |
+    | Danish | Sentiment Classification | [`angry-tweets`](https://huggingface.co/datasets/DDSC/angry-tweets), [`danish-sentiment-in-context`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | Danish | Summarization | [`nordjylland-news`](https://huggingface.co/datasets/alexandrainst/nordjylland-news-summarization) |
+    | Danish | Word-in-Context | [`danwic`](https://github.com/kuhumcst/danish-semantic-reasoning-benchmark) |
+    | English | Knowledge | [`ARC-C`](https://arxiv.org/abs/1803.05457), [`ARC-E`](https://arxiv.org/abs/1803.05457), [`MMLU`](https://arxiv.org/abs/2009.03300), [`MMLU-Pro`](https://arxiv.org/abs/2406.01574) |
+    | English | Other task groups | [`HellaSwag`](https://arxiv.org/abs/1905.07830), [`IFEval`](https://arxiv.org/abs/2311.07911), [`RULER 32k`](https://arxiv.org/abs/2404.06654), [`GSM8K`](https://arxiv.org/abs/2110.14168), [`TruthfulQA`](https://arxiv.org/abs/2109.07958) |
+    | Agentic | Code and Tool Calling | [`HumanEval`](https://arxiv.org/abs/2107.03374), [`MBPP p@1`](https://arxiv.org/abs/2108.07732), [`BFCL`](https://arxiv.org/abs/2407.07770) |
+
+The main result is that Munin is highly competitive on the Danish evaluations, and in several task groups, our post-trained models match or improve on the original instruct models. The strongest results are on Danish knowledge, reading comprehension, summarization, and natural language inference, where some Munin models are ahead within uncertainty. This is the behavior we wanted to see: post-training moves the models toward stronger Danish performance while retaining a useful general capability profile.
+
+The English and agentic task results are more mixed. The original instruct models are generally stronger on code, tool calling, and several English benchmarks, which reflects that Munin 1.0 is now primarily focused on Danish text capabilities. These gaps are important, because they point directly to the next stage of work: keeping the Danish gains while investing more deliberately in reasoning, multilingual retention, and agentic capabilities.
+
+We also ran a focused Danish creative writing tournament across 360 rated matches, judged by Qwen3.5-397B-A17B. We chose this judge due to its strong Danish language capabilities.
+
+This tournament is not a broad benchmark of model quality, but it is useful because creative writing is a high-signal Danish task: it tests fluency, register, coherence, and whether the model can produce text that feels natural rather than merely correct. [Munin Qwen 9B](https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B) separates clearly from the rest of the field with a 96-9 record, while [Munin Apertus 8B](https://huggingface.co/danish-foundation-models/munin-apertus-8b) places second and [Munin Ministral 8B](https://huggingface.co/danish-foundation-models/munin-ministral3-8B) also beats its original counterpart.
+
+<div class="md-typeset__table">
+  <table class="dfm-tournament-table">
+    <caption>Danish creative writing tournament ranking; W-L is aggregate win-loss</caption>
+    <thead>
+      <tr>
+        <th scope="col">Rank</th>
+        <th scope="col">Model</th>
+        <th scope="col">W-L</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="dfm-model-munin">
+        <td>1</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-qwen3.5-9B">Munin Qwen 9B</a></strong></td>
+        <td>96-9</td>
+      </tr>
+      <tr class="dfm-model-munin">
+        <td>2</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-apertus-8b">Munin Apertus 8B</a></strong></td>
+        <td>56-45</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Original Qwen 9B</td>
+        <td>43-53</td>
+      </tr>
+      <tr class="dfm-model-munin">
+        <td>4</td>
+        <td><strong><a href="https://huggingface.co/danish-foundation-models/munin-ministral3-8B">Munin Ministral 8B</a></strong></td>
+        <td>43-54</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Original Apertus 8B</td>
+        <td>30-65</td>
+      </tr>
+      <tr>
+        <td>6</td>
+        <td>Original Ministral 8B</td>
+        <td>26-68</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Contributors
+
+Rasmus Larsen led training, performed experiments, built synthetic datasets and benchmarks, and drafted the release announcement.
+
+Oliver Kinch built synthetic datasets and benchmarks.
+
+Vladimir Salnikov and Jacob Nielsen contributed to datasets.
+
+Dan Saattrup Smart developed benchmarks and led the integration into EuroEval.
+
+Torben Blach contributed with project management and coordination.
+
+## Acknowledgements
+
+The work was supported by the Danish Foundation Models project, funded by the Danish government. This work was partially supported by DeiC National HPC (grant agreement DeiC-SDU-N5-2025162).

--- a/en/docs/news/results/munin-10-full-results.md
+++ b/en/docs/news/results/munin-10-full-results.md
@@ -1,0 +1,68 @@
+---
+hide:
+  - navigation
+---
+
+# Munin 1.0 Full Evaluation Results
+
+Scores are percentages. Standard errors are percentage points. Deltas are `Munin - Original`; Danish deltas were computed from the reported scores with propagated standard errors.
+
+Task groupings use the EuroEval Danish task taxonomy for Danish datasets. Aggregate rows are unweighted means across evals in the task; aggregate standard error is `sqrt(sum(SE_i^2)) / n`, assuming independent evaluation estimates.
+
+| Suite | Task | Metric | Benchmark | Apertus Original ± SE | Apertus Munin ± SE | Apertus Δ ± SE | Ministral Original ± SE | Ministral Munin ± SE | Ministral Δ ± SE | Qwen Original ± SE | Qwen Munin ± SE | Qwen Δ ± SE |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Danish | Common-sense Reasoning | MCC | Average (3 evals) | 33.11 ± 0.86 | 29.40 ± 1.28 | -3.71 ± 1.54 | 52.37 ± 1.19 | 50.21 ± 1.29 | -2.16 ± 1.76 | 64.64 ± 0.72 | 62.22 ± 0.88 | -2.42 ± 1.14 |
+| Danish | Common-sense Reasoning | MCC | goldenswag-da | 47.66 ± 1.23 | 38.65 ± 2.50 | -9.01 ± 2.79 | 68.89 ± 1.49 | 64.52 ± 1.51 | -4.37 ± 2.12 | 85.94 ± 0.79 | 78.94 ± 1.19 | -7.00 ± 1.43 |
+| Danish | Common-sense Reasoning | MCC | hellaswag-da | 39.19 ± 1.01 | 36.89 ± 1.88 | -2.30 ± 2.13 | 55.79 ± 2.04 | 51.80 ± 2.79 | -3.99 ± 3.46 | 73.28 ± 0.99 | 67.50 ± 1.35 | -5.78 ± 1.67 |
+| Danish | Common-sense Reasoning | MCC | winogrande-da | 12.48 ± 2.02 | 12.65 ± 2.25 | +0.17 ± 3.02 | 32.43 ± 2.54 | 34.32 ± 2.21 | +1.89 ± 3.37 | 34.71 ± 1.75 | 40.22 ± 1.93 | +5.51 ± 2.61 |
+| Danish | Grammatical Error Detection | micro-F1 | Average (1 eval) | 18.00 ± 1.31 | 17.35 ± 1.06 | -0.65 ± 1.69 | 21.72 ± 2.04 | 17.66 ± 0.74 | -4.06 ± 2.17 | 20.37 ± 1.25 | 20.74 ± 1.14 | +0.37 ± 1.69 |
+| Danish | Grammatical Error Detection | micro-F1 | gerlangmod-da | 18.00 ± 1.31 | 17.35 ± 1.06 | -0.65 ± 1.69 | 21.72 ± 2.04 | 17.66 ± 0.74 | -4.06 ± 2.17 | 20.37 ± 1.25 | 20.74 ± 1.14 | +0.37 ± 1.69 |
+| Danish | Instruction-following | Accuracy | Average (1 eval) | 69.00 ± 1.06 | 51.43 ± 1.38 | -17.57 ± 1.74 | 66.67 ± 1.31 | 74.38 ± 0.94 | +7.71 ± 1.61 | 81.56 ± 0.85 | 77.88 ± 0.89 | -3.68 ± 1.23 |
+| Danish | Instruction-following | Accuracy | ifeval-da | 69.00 ± 1.06 | 51.43 ± 1.38 | -17.57 ± 1.74 | 66.67 ± 1.31 | 74.38 ± 0.94 | +7.71 ± 1.61 | 81.56 ± 0.85 | 77.88 ± 0.89 | -3.68 ± 1.23 |
+| Danish | Knowledge | MCC | Average (5 evals) | 58.89 ± 0.73 | 62.29 ± 0.72 | +3.41 ± 1.03 | 73.58 ± 0.52 | 68.48 ± 0.58 | -5.09 ± 0.78 | 75.98 ± 0.52 | 77.64 ± 0.50 | +1.67 ± 0.72 |
+| Danish | Knowledge | MCC | arc-da | 63.02 ± 1.58 | 65.87 ± 1.43 | +2.85 ± 2.13 | 84.17 ± 0.80 | 81.86 ± 0.77 | -2.31 ± 1.11 | 88.30 ± 0.80 | 88.82 ± 0.72 | +0.52 ± 1.08 |
+| Danish | Knowledge | MCC | dameta | 62.52 ± 1.58 | 67.63 ± 1.66 | +5.11 ± 2.29 | 74.93 ± 1.21 | 66.52 ± 1.48 | -8.41 ± 1.91 | 76.70 ± 0.68 | 78.14 ± 1.01 | +1.44 ± 1.22 |
+| Danish | Knowledge | MCC | danish-citizen-tests | 72.31 ± 2.18 | 73.25 ± 2.06 | +0.94 ± 3.00 | 78.01 ± 0.94 | 71.59 ± 1.71 | -6.42 ± 1.95 | 76.92 ± 1.67 | 82.16 ± 1.53 | +5.24 ± 2.26 |
+| Danish | Knowledge | MCC | danske-talemaader | 55.11 ± 1.80 | 62.44 ± 1.68 | +7.33 ± 2.46 | 73.14 ± 1.56 | 68.47 ± 1.40 | -4.67 ± 2.10 | 75.67 ± 1.43 | 76.72 ± 0.92 | +1.05 ± 1.70 |
+| Danish | Knowledge | MCC | mmlu-da | 41.47 ± 0.58 | 42.27 ± 1.11 | +0.80 ± 1.25 | 57.63 ± 1.11 | 53.97 ± 0.94 | -3.66 ± 1.45 | 62.30 ± 0.90 | 62.38 ± 1.20 | +0.08 ± 1.50 |
+| Danish | Linguistic Acceptability | MCC | Average (2 evals) | 32.95 ± 1.19 | 29.34 ± 2.38 | -3.62 ± 2.66 | 43.37 ± 1.85 | 18.89 ± 3.06 | -24.48 ± 3.57 | 49.25 ± 1.68 | 52.19 ± 1.30 | +2.95 ± 2.12 |
+| Danish | Linguistic Acceptability | MCC | dala | 29.38 ± 1.82 | 25.56 ± 3.12 | -3.82 ± 3.61 | 39.49 ± 2.66 | 16.99 ± 4.12 | -22.50 ± 4.90 | 45.65 ± 2.09 | 49.07 ± 1.55 | +3.42 ± 2.60 |
+| Danish | Linguistic Acceptability | MCC | scala-da | 36.53 ± 1.53 | 33.11 ± 3.60 | -3.42 ± 3.91 | 47.25 ± 2.58 | 20.79 ± 4.52 | -26.46 ± 5.20 | 52.84 ± 2.62 | 55.31 ± 2.08 | +2.47 ± 3.35 |
+| Danish | Multiple-choice Reading Comprehension | MCC | Average (1 eval) | 67.09 ± 1.02 | 65.99 ± 2.04 | -1.10 ± 2.28 | 85.94 ± 1.39 | 84.42 ± 1.12 | -1.52 ± 1.79 | 87.19 ± 1.17 | 87.35 ± 1.27 | +0.16 ± 1.73 |
+| Danish | Multiple-choice Reading Comprehension | MCC | belebele-da | 67.09 ± 1.02 | 65.99 ± 2.04 | -1.10 ± 2.28 | 85.94 ± 1.39 | 84.42 ± 1.12 | -1.52 ± 1.79 | 87.19 ± 1.17 | 87.35 ± 1.27 | +0.16 ± 1.73 |
+| Danish | Named Entity Recognition | micro-F1 | Average (2 evals) | 49.33 ± 1.40 | 47.60 ± 1.33 | -1.72 ± 1.93 | 61.13 ± 1.01 | 51.41 ± 1.76 | -9.72 ± 2.03 | 69.12 ± 1.16 | 69.63 ± 1.23 | +0.51 ± 1.69 |
+| Danish | Named Entity Recognition | micro-F1 | dane | 51.69 ± 1.30 | 48.66 ± 1.53 | -3.03 ± 2.01 | 66.16 ± 1.42 | 53.80 ± 1.51 | -12.36 ± 2.07 | 74.51 ± 0.75 | 76.33 ± 0.85 | +1.82 ± 1.13 |
+| Danish | Named Entity Recognition | micro-F1 | dansk | 46.97 ± 2.48 | 46.55 ± 2.18 | -0.42 ± 3.30 | 56.11 ± 1.44 | 49.02 ± 3.19 | -7.09 ± 3.50 | 63.74 ± 2.20 | 62.94 ± 2.31 | -0.80 ± 3.19 |
+| Danish | Natural Language Inference | MCC | Average (2 evals) | 48.80 ± 2.34 | 52.09 ± 2.62 | +3.29 ± 3.51 | 25.75 ± 1.58 | 58.18 ± 2.22 | +32.42 ± 2.73 | 53.80 ± 1.93 | 65.63 ± 2.01 | +11.83 ± 2.79 |
+| Danish | Natural Language Inference | MCC | danish-entailment | 57.24 ± 3.67 | 64.03 ± 4.45 | +6.79 ± 5.77 | 51.51 ± 3.17 | 55.54 ± 3.61 | +4.03 ± 4.80 | 62.10 ± 2.55 | 67.72 ± 1.46 | +5.62 ± 2.94 |
+| Danish | Natural Language Inference | MCC | danish-lexical-inference | 40.37 ± 2.90 | 40.15 ± 2.76 | -0.22 ± 4.00 | 0.00 ± 0.00 | 60.82 ± 2.59 | +60.82 ± 2.59 | 45.51 ± 2.91 | 63.55 ± 3.75 | +18.04 ± 4.75 |
+| Danish | Reading Comprehension | F1 | Average (2 evals) | 70.75 ± 0.51 | 69.41 ± 0.56 | -1.35 ± 0.76 | 69.71 ± 0.72 | 71.23 ± 0.81 | +1.52 ± 1.08 | 70.84 ± 0.55 | 71.96 ± 0.68 | +1.12 ± 0.88 |
+| Danish | Reading Comprehension | F1 | multi-wiki-qa-da | 77.94 ± 0.97 | 74.11 ± 1.10 | -3.83 ± 1.47 | 75.77 ± 1.34 | 79.52 ± 1.43 | +3.75 ± 1.96 | 79.28 ± 0.78 | 79.51 ± 1.20 | +0.23 ± 1.43 |
+| Danish | Reading Comprehension | F1 | scandiqa-da | 63.57 ± 0.34 | 64.70 ± 0.25 | +1.13 ± 0.42 | 63.65 ± 0.52 | 62.95 ± 0.76 | -0.70 ± 0.92 | 62.39 ± 0.78 | 64.40 ± 0.66 | +2.01 ± 1.02 |
+| Danish | Sentiment Classification | MCC | Average (2 evals) | 57.89 ± 0.97 | 54.30 ± 1.10 | -3.59 ± 1.46 | 60.37 ± 0.97 | 59.56 ± 1.41 | -0.81 ± 1.71 | 64.89 ± 0.93 | 64.69 ± 1.00 | -0.20 ± 1.36 |
+| Danish | Sentiment Classification | MCC | angry-tweets | 52.17 ± 0.96 | 48.76 ± 0.94 | -3.41 ± 1.34 | 52.91 ± 0.72 | 52.71 ± 1.32 | -0.20 ± 1.50 | 55.73 ± 1.16 | 56.26 ± 1.07 | +0.53 ± 1.58 |
+| Danish | Sentiment Classification | MCC | danish-sentiment-in-context | 63.61 ± 1.68 | 59.84 ± 1.99 | -3.77 ± 2.60 | 67.83 ± 1.81 | 66.40 ± 2.49 | -1.43 ± 3.08 | 74.05 ± 1.45 | 73.11 ± 1.68 | -0.94 ± 2.22 |
+| Danish | Summarization | chrF++ | Average (1 eval) | 37.56 ± 0.20 | 36.88 ± 0.20 | -0.68 ± 0.28 | 35.09 ± 0.35 | 36.97 ± 0.21 | +1.88 ± 0.41 | 36.51 ± 0.28 | 36.66 ± 0.44 | +0.15 ± 0.52 |
+| Danish | Summarization | chrF++ | nordjylland-news | 37.56 ± 0.20 | 36.88 ± 0.20 | -0.68 ± 0.28 | 35.09 ± 0.35 | 36.97 ± 0.21 | +1.88 ± 0.41 | 36.51 ± 0.28 | 36.66 ± 0.44 | +0.15 ± 0.52 |
+| Danish | Word-in-Context | MCC | Average (1 eval) | 11.83 ± 2.20 | 8.71 ± 3.46 | -3.12 ± 4.10 | 29.87 ± 1.70 | 23.27 ± 3.18 | -6.60 ± 3.61 | 44.60 ± 2.06 | 40.11 ± 3.46 | -4.49 ± 4.03 |
+| Danish | Word-in-Context | MCC | danwic | 11.83 ± 2.20 | 8.71 ± 3.46 | -3.12 ± 4.10 | 29.87 ± 1.70 | 23.27 ± 3.18 | -6.60 ± 3.61 | 44.60 ± 2.06 | 40.11 ± 3.46 | -4.49 ± 4.03 |
+| English | Common-sense Reasoning | Accuracy | Average (1 eval) | 58.70 ± 0.50 | 23.20 ± 0.40 | -35.50 ± 0.60 | 73.10 ± 0.40 | 59.60 ± 0.50 | -13.50 ± 0.70 | 90.00 ± 0.30 | 85.70 ± 0.30 | -4.30 ± 0.50 |
+| English | Common-sense Reasoning | Accuracy | HellaSwag | 58.7 ± 0.5 | 23.2 ± 0.4 | -35.5 ± 0.6 | 73.1 ± 0.4 | 59.6 ± 0.5 | -13.5 ± 0.7 | 90.0 ± 0.3 | 85.7 ± 0.3 | -4.3 ± 0.5 |
+| English | Instruction-following | Accuracy | Average (1 eval) | 73.30 ± 1.90 | 54.70 ± 2.00 | -18.50 ± 2.70 | 70.40 ± 1.80 | 69.80 ± 1.90 | -0.60 ± 2.70 | 89.60 ± 1.50 | 78.60 ± 1.80 | -11.00 ± 2.30 |
+| English | Instruction-following | Accuracy | IFEval | 73.3 ± 1.9 | 54.7 ± 2.0 | -18.5 ± 2.7 | 70.4 ± 1.8 | 69.8 ± 1.9 | -0.6 ± 2.7 | 89.6 ± 1.5 | 78.6 ± 1.8 | -11.0 ± 2.3 |
+| English | Knowledge | Accuracy | Average (4 evals) | 50.27 ± 0.46 | 41.92 ± 0.45 | -8.35 ± 0.65 | 81.72 ± 0.26 | 72.97 ± 0.29 | -8.75 ± 0.42 | 79.15 ± 0.22 | 82.40 ± 0.24 | +3.23 ± 0.33 |
+| English | Knowledge | Accuracy | ARC-C | 55.5 ± 1.5 | 55.0 ± 1.5 | -0.5 ± 2.1 | 90.8 ± 0.8 | 88.5 ± 0.9 | -2.3 ± 1.3 | 96.1 ± 0.6 | 93.8 ± 0.7 | -2.3 ± 0.9 |
+| English | Knowledge | Accuracy | ARC-E | 72.9 ± 0.9 | 74.2 ± 0.9 | +1.3 ± 1.3 | 96.3 ± 0.4 | 94.6 ± 0.5 | -1.7 ± 0.6 | 98.5 ± 0.3 | 98.3 ± 0.3 | -0.2 ± 0.4 |
+| English | Knowledge | Accuracy | MMLU | 39.8 ± 0.4 | 31.7 ± 0.4 | -8.1 ± 0.6 | 71.3 ± 0.4 | 67.8 ± 0.4 | -3.6 ± 0.6 | 41.4 ± 0.4 | 76.6 ± 0.4 | +35.2 ± 0.6 |
+| English | Knowledge | Accuracy | MMLU-Pro | 32.9 ± 0.4 | 6.8 ± 0.2 | -26.1 ± 0.5 | 68.5 ± 0.4 | 41.0 ± 0.4 | -27.4 ± 0.6 | 80.6 ± 0.4 | 60.9 ± 0.4 | -19.8 ± 0.6 |
+| English | Long-context | Accuracy | Average (1 eval) | 34.60 ± 2.10 | 35.80 ± 2.10 | +1.20 ± 3.00 | 51.40 ± 2.20 | 49.40 ± 2.20 | -2.00 ± 3.20 | 67.20 ± 2.10 | 54.60 ± 2.20 | -12.60 ± 3.10 |
+| English | Long-context | Accuracy | RULER 32k | 34.6 ± 2.1 | 35.8 ± 2.1 | +1.2 ± 3.0 | 51.4 ± 2.2 | 49.4 ± 2.2 | -2.0 ± 3.2 | 67.2 ± 2.1 | 54.6 ± 2.2 | -12.6 ± 3.1 |
+| English | Math | Accuracy | Average (1 eval) | 68.10 ± 1.30 | 56.70 ± 1.40 | -11.40 ± 1.90 | 92.20 ± 0.70 | 82.30 ± 1.10 | -9.90 ± 1.30 | 94.80 ± 0.60 | 92.20 ± 0.70 | -2.60 ± 1.00 |
+| English | Math | Accuracy | GSM8K | 68.1 ± 1.3 | 56.7 ± 1.4 | -11.4 ± 1.9 | 92.2 ± 0.7 | 82.3 ± 1.1 | -9.9 ± 1.3 | 94.8 ± 0.6 | 92.2 ± 0.7 | -2.6 ± 1.0 |
+| English | Truthfulness | Accuracy | Average (1 eval) | 16.80 ± 1.30 | 15.70 ± 1.30 | -1.10 ± 1.80 | 64.70 ± 1.70 | 63.30 ± 1.70 | -1.50 ± 2.40 | 78.10 ± 1.40 | 74.20 ± 1.50 | -3.90 ± 2.10 |
+| English | Truthfulness | Accuracy | TruthfulQA | 16.8 ± 1.3 | 15.7 ± 1.3 | -1.1 ± 1.8 | 64.7 ± 1.7 | 63.3 ± 1.7 | -1.5 ± 2.4 | 78.1 ± 1.4 | 74.2 ± 1.5 | -3.9 ± 2.1 |
+| Agentic | Code | pass@1 | Average (2 evals) | 46.75 ± 2.49 | 39.20 ± 2.38 | -7.55 ± 3.44 | 75.05 ± 2.13 | 49.20 ± 2.31 | -25.85 ± 3.13 | 82.95 ± 1.84 | 77.20 ± 2.06 | -5.75 ± 2.72 |
+| Agentic | Code | pass@1 | HumanEval | 42.1 ± 3.9 | 29.9 ± 3.6 | -12.2 ± 5.3 | 76.2 ± 3.3 | 29.3 ± 3.6 | -47.0 ± 4.9 | 87.8 ± 2.6 | 80.5 ± 3.1 | -7.3 ± 4.0 |
+| Agentic | Code | pass@1 | MBPP p@1 | 51.4 ± 3.1 | 48.5 ± 3.1 | -2.9 ± 4.4 | 73.9 ± 2.7 | 69.1 ± 2.9 | -4.7 ± 3.9 | 78.1 ± 2.6 | 73.9 ± 2.7 | -4.2 ± 3.7 |
+| Agentic | Tool Calling | Accuracy | Average (1 eval) | 52.40 ± 0.80 | 43.10 ± 0.80 | -9.30 ± 1.10 | 75.00 ± 0.70 | 49.20 ± 0.80 | -25.80 ± 1.00 | 79.40 ± 0.60 | 75.80 ± 0.70 | -3.60 ± 0.90 |
+| Agentic | Tool Calling | Accuracy | BFCL | 52.4 ± 0.8 | 43.1 ± 0.8 | -9.3 ± 1.1 | 75.0 ± 0.7 | 49.2 ± 0.8 | -25.8 ± 1.0 | 79.4 ± 0.6 | 75.8 ± 0.7 | -3.6 ± 0.9 |


### PR DESCRIPTION
## Summary
- add the English Munin 1.0 release note and full benchmark results page
- add the Danish release note, linking to the English full results page
- feature the release on the English and Danish front pages with shared card styling

## Validation
- UV_CACHE_DIR=/private/tmp/uv-cache uv run mkdocs build -f en/mkdocs.yml
- UV_CACHE_DIR=/private/tmp/uv-cache uv run mkdocs build -f da/mkdocs.yml

Both builds completed successfully. MkDocs emitted existing nav/tag deprecation warnings; the Danish build also confirmed the absolute English full-results link is left as-is.